### PR TITLE
[FEAT] 22 상품관 목록 화면 구현

### DIFF
--- a/src/constants/routePaths.ts
+++ b/src/constants/routePaths.ts
@@ -10,6 +10,7 @@ export const ROUTE_PATHS = {
   activityEnvironment: '/activities/environment',
   activitySocial: '/activities/social',
   activitySocialDonation: '/esg/social/donation',
+  activitySocialStore: '/esg/social/store',
   donationDetail: '/esg/social/donations/:donationId',
   activityGovernance: '/activities/governance',
   finance: '/finance',

--- a/src/index.css
+++ b/src/index.css
@@ -87,6 +87,10 @@
 }
 
 @layer base {
+  html {
+    overflow-y: scroll;
+  }
+
   body {
     @apply bg-bg-light text-font-main font-pretendard;
   }

--- a/src/pages/activities/DonationPage.tsx
+++ b/src/pages/activities/DonationPage.tsx
@@ -43,7 +43,7 @@ export function DonationPage() {
   }, [])
 
   const handleBack = () => {
-    navigate(-1)
+    navigate(ROUTE_PATHS.home)
   }
 
   const handleBottomNavigation = (key: string) => {

--- a/src/pages/activities/ValueStorePage.tsx
+++ b/src/pages/activities/ValueStorePage.tsx
@@ -37,7 +37,7 @@ export function ValueStorePage() {
   }, [])
 
   const handleBack = () => {
-    navigate(-1)
+    navigate(ROUTE_PATHS.home)
   }
 
   const handleBottomNavigation = (key: string) => {

--- a/src/pages/activities/ValueStorePage.tsx
+++ b/src/pages/activities/ValueStorePage.tsx
@@ -67,33 +67,34 @@ export function ValueStorePage() {
         />
       }
       nav={<BottomNavigation value="home" onChange={handleBottomNavigation} />}
-      className="bg-gray-50"
     >
       <SocialActivityTabs activeTab="store" />
 
       {isLoading ? (
-        <section className="flex flex-col gap-4 pt-2">
-          <div className="flex items-center justify-between px-3">
-            <div className="h-5 w-28 animate-pulse rounded-full bg-gray-300" />
-            <div className="h-4 w-20 animate-pulse rounded-full bg-primary-100" />
-          </div>
+        <div className="flex flex-col gap-6">
+          <section className="space-y-4 pt-2">
+            <div className="flex items-center justify-between px-3">
+              <div className="h-5 w-28 animate-pulse rounded-full bg-gray-300" />
+              <div className="h-4 w-20 animate-pulse rounded-full bg-primary-100" />
+            </div>
 
-          <div className="grid grid-cols-2 gap-3">
-            {Array.from({ length: 6 }).map((_, index) => (
-              <div key={index} className="overflow-hidden rounded-control bg-white shadow-[0_2px_8px_rgba(0,0,0,0.05)]">
-                <div className="h-[159px] animate-pulse bg-primary-100" />
-                <div className="space-y-3 px-3 py-[14px]">
-                  <div className="h-4 w-4/5 animate-pulse rounded-full bg-gray-300" />
-                  <div className="h-5 w-1/2 animate-pulse rounded-full bg-gray-300" />
-                  <div className="flex gap-1">
-                    <div className="h-6 w-12 animate-pulse rounded-badge bg-primary-50" />
-                    <div className="h-6 w-16 animate-pulse rounded-badge bg-gray-100" />
+            <div className="grid grid-cols-2 gap-3">
+              {Array.from({ length: 6 }).map((_, index) => (
+                <div key={index} className="overflow-hidden rounded-control bg-white shadow-[0_2px_8px_rgba(0,0,0,0.05)]">
+                  <div className="h-[159px] animate-pulse bg-primary-100" />
+                  <div className="space-y-3 px-3 py-[14px]">
+                    <div className="h-4 w-4/5 animate-pulse rounded-full bg-gray-300" />
+                    <div className="h-5 w-1/2 animate-pulse rounded-full bg-gray-300" />
+                    <div className="flex gap-1">
+                      <div className="h-6 w-12 animate-pulse rounded-badge bg-primary-50" />
+                      <div className="h-6 w-16 animate-pulse rounded-badge bg-gray-100" />
+                    </div>
                   </div>
                 </div>
-              </div>
-            ))}
-          </div>
-        </section>
+              ))}
+            </div>
+          </section>
+        </div>
       ) : null}
 
       {!isLoading && error ? (
@@ -109,28 +110,30 @@ export function ValueStorePage() {
       ) : null}
 
       {!isLoading && !error && productData ? (
-        <div className="flex flex-col gap-4 pt-2">
-          <section className="flex items-center justify-between px-3">
-            <h2 className="text-lg leading-[120%] font-semibold text-gray-700">판매중인 상품</h2>
-            <span className="text-sm leading-[120%] font-medium text-primary-400">
-              {productData.products.length}개의 제품
-            </span>
-          </section>
+        <div className="flex flex-col gap-6 pt-2">
+          <section className="space-y-4">
+            <div className="flex items-center justify-between px-3">
+              <h2 className="text-lg leading-[120%] font-semibold text-gray-700">판매중인 상품</h2>
+              <span className="text-sm leading-[120%] font-medium text-primary-400">
+                {productData.products.length}개의 제품
+              </span>
+            </div>
 
-          {productData.products.length === 0 ? (
-            <Card className="border-dashed bg-gray-50 px-5 py-10 text-center shadow-none">
-              <p className="text-lg font-semibold text-font-main">등록된 가치가게 상품이 없어요</p>
-              <p className="mt-2 text-sm leading-6 text-font-sub">
-                새로운 상품이 준비되면 이곳에서 바로 확인할 수 있어요.
-              </p>
-            </Card>
-          ) : (
-            <section className="grid grid-cols-2 gap-3">
-              {productData.products.map((product) => (
-                <ValueStoreProductCard key={product.productId} product={product} />
-              ))}
-            </section>
-          )}
+            {productData.products.length === 0 ? (
+              <Card className="border-dashed bg-gray-50 px-5 py-10 text-center shadow-none">
+                <p className="text-lg font-semibold text-font-main">등록된 가치가게 상품이 없어요</p>
+                <p className="mt-2 text-sm leading-6 text-font-sub">
+                  새로운 상품이 준비되면 이곳에서 바로 확인할 수 있어요.
+                </p>
+              </Card>
+            ) : (
+              <div className="grid grid-cols-2 gap-3">
+                {productData.products.map((product) => (
+                  <ValueStoreProductCard key={product.productId} product={product} />
+                ))}
+              </div>
+            )}
+          </section>
         </div>
       ) : null}
     </MainLayout>

--- a/src/pages/activities/ValueStorePage.tsx
+++ b/src/pages/activities/ValueStorePage.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Button, Card, IconButton } from '../../components/common'
+import { Icons } from '../../components/common'
+import BottomNavigation from '../../components/layout/BottomNavigation'
+import Header from '../../components/layout/Header'
+import MainLayout from '../../components/layout/MainLayout'
+import { ROUTE_PATHS } from '../../constants/routePaths'
+import { getValueStoreProducts } from '../../services/productService'
+import type { ValueStoreProductListResponse } from '../../types/product'
+import { SocialActivityTabs } from './components/SocialActivityTabs'
+import { ValueStoreProductCard } from './components/ValueStoreProductCard'
+
+export function ValueStorePage() {
+  const navigate = useNavigate()
+  const [productData, setProductData] = useState<ValueStoreProductListResponse | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  const fetchProducts = async () => {
+    setIsLoading(true)
+    setError('')
+
+    try {
+      const response = await getValueStoreProducts()
+      setProductData(response)
+    } catch (fetchError) {
+      console.error(fetchError)
+      setError('가치가게 상품 정보를 불러오지 못했어요. 잠시 후 다시 시도해주세요.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void fetchProducts()
+  }, [])
+
+  const handleBack = () => {
+    navigate(-1)
+  }
+
+  const handleBottomNavigation = (key: string) => {
+    if (key === 'home') {
+      navigate(ROUTE_PATHS.home)
+      return
+    }
+
+    if (key === 'finance') {
+      navigate(ROUTE_PATHS.finance)
+      return
+    }
+
+    if (key === 'mypage') {
+      navigate(ROUTE_PATHS.my)
+    }
+  }
+
+  return (
+    <MainLayout
+      header={
+        <Header
+          left={
+            <IconButton label="뒤로가기" icon={<Icons.Back className="text-font-main" />} onClick={handleBack} />
+          }
+          title="S 활동"
+        />
+      }
+      nav={<BottomNavigation value="home" onChange={handleBottomNavigation} />}
+      className="bg-gray-50"
+    >
+      <SocialActivityTabs activeTab="store" />
+
+      {isLoading ? (
+        <section className="flex flex-col gap-4 pt-2">
+          <div className="flex items-center justify-between px-3">
+            <div className="h-5 w-28 animate-pulse rounded-full bg-gray-300" />
+            <div className="h-4 w-20 animate-pulse rounded-full bg-primary-100" />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            {Array.from({ length: 6 }).map((_, index) => (
+              <div key={index} className="overflow-hidden rounded-control bg-white shadow-[0_2px_8px_rgba(0,0,0,0.05)]">
+                <div className="h-[159px] animate-pulse bg-primary-100" />
+                <div className="space-y-3 px-3 py-[14px]">
+                  <div className="h-4 w-4/5 animate-pulse rounded-full bg-gray-300" />
+                  <div className="h-5 w-1/2 animate-pulse rounded-full bg-gray-300" />
+                  <div className="flex gap-1">
+                    <div className="h-6 w-12 animate-pulse rounded-badge bg-primary-50" />
+                    <div className="h-6 w-16 animate-pulse rounded-badge bg-gray-100" />
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {!isLoading && error ? (
+        <section className="pt-2">
+          <div className="rounded-card border border-red-100 bg-red-50 px-5 py-6 text-center shadow-card">
+            <h2 className="text-lg font-semibold text-font-main">가치가게 상품을 불러오지 못했어요</h2>
+            <p className="mt-2 text-sm leading-6 text-font-sub">{error}</p>
+            <Button className="mt-5" onClick={() => void fetchProducts()}>
+              다시 시도
+            </Button>
+          </div>
+        </section>
+      ) : null}
+
+      {!isLoading && !error && productData ? (
+        <div className="flex flex-col gap-4 pt-2">
+          <section className="flex items-center justify-between px-3">
+            <h2 className="text-lg leading-[120%] font-semibold text-gray-700">판매중인 상품</h2>
+            <span className="text-sm leading-[120%] font-medium text-primary-400">
+              {productData.products.length}개의 제품
+            </span>
+          </section>
+
+          {productData.products.length === 0 ? (
+            <Card className="border-dashed bg-gray-50 px-5 py-10 text-center shadow-none">
+              <p className="text-lg font-semibold text-font-main">등록된 가치가게 상품이 없어요</p>
+              <p className="mt-2 text-sm leading-6 text-font-sub">
+                새로운 상품이 준비되면 이곳에서 바로 확인할 수 있어요.
+              </p>
+            </Card>
+          ) : (
+            <section className="grid grid-cols-2 gap-3">
+              {productData.products.map((product) => (
+                <ValueStoreProductCard key={product.productId} product={product} />
+              ))}
+            </section>
+          )}
+        </div>
+      ) : null}
+    </MainLayout>
+  )
+}

--- a/src/pages/activities/components/SocialActivityTabs.tsx
+++ b/src/pages/activities/components/SocialActivityTabs.tsx
@@ -15,7 +15,7 @@ export const SocialActivityTabs = ({ activeTab }: SocialActivityTabsProps) => {
   const navigate = useNavigate()
 
   return (
-    <div className="mx-[-16px] flex border-b border-gray-200 bg-white">
+    <div className="sticky top-(--header-h) z-40 mx-[-16px] flex border-b border-gray-200 bg-white">
       {tabItems.map((item) => {
         const isActive = item.value === activeTab
 

--- a/src/pages/activities/components/SocialActivityTabs.tsx
+++ b/src/pages/activities/components/SocialActivityTabs.tsx
@@ -1,34 +1,50 @@
+import { useNavigate } from 'react-router-dom'
+import { ROUTE_PATHS } from '../../../constants/routePaths'
+
 interface SocialActivityTabsProps {
   activeTab: 'donation' | 'store' | 'volunteer'
 }
 
 const tabItems = [
-  { value: 'donation', label: '기부' },
-  { value: 'store', label: '가치가게' },
-  { value: 'volunteer', label: '봉사' },
+  { value: 'donation', label: '기부', path: ROUTE_PATHS.activitySocialDonation },
+  { value: 'store', label: '가치가게', path: ROUTE_PATHS.activitySocialStore },
+  { value: 'volunteer', label: '봉사', path: undefined },
 ] as const
 
 export const SocialActivityTabs = ({ activeTab }: SocialActivityTabsProps) => {
+  const navigate = useNavigate()
+
   return (
-    <div className="mx-[-16px] flex bg-white">
+    <div className="mx-[-16px] flex border-b border-gray-200 bg-white">
       {tabItems.map((item) => {
         const isActive = item.value === activeTab
 
         return (
-          <div
+          <button
+            type="button"
             key={item.value}
-            className={`relative flex h-12 w-1/3 items-center justify-center border-b ${
-              isActive ? 'border-primary-500' : 'border-gray-200'
+            role="tab"
+            aria-selected={isActive}
+            onClick={() => {
+              if (item.path && !isActive) {
+                navigate(item.path)
+              }
+            }}
+            className={`relative flex h-12 w-1/3 items-center justify-center transition-colors ${
+              isActive ? 'text-font-main' : 'text-gray-400'
             }`}
           >
             <span
-              className={`text-base font-semibold tracking-[-0.02em] ${
-                isActive ? 'text-font-main' : 'text-gray-400'
-              }`}
+              className="text-base font-semibold tracking-[-0.02em]"
             >
               {item.label}
             </span>
-          </div>
+            <span
+              className={`absolute inset-x-0 bottom-0 h-px transition-colors ${
+                isActive ? 'bg-primary-500' : 'bg-transparent'
+              }`}
+            />
+          </button>
         )
       })}
     </div>

--- a/src/pages/activities/components/ValueStoreProductCard.tsx
+++ b/src/pages/activities/components/ValueStoreProductCard.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react'
+import { Badge, Card } from '../../../components/common'
+import type { ValueStoreProduct } from '../../../types/product'
+
+interface ValueStoreProductCardProps {
+  product: ValueStoreProduct
+  onClick?: (productId: number) => void
+}
+
+const formatPrice = (price: number) => `${new Intl.NumberFormat('ko-KR').format(price)}원`
+
+export const ValueStoreProductCard = ({ product, onClick }: ValueStoreProductCardProps) => {
+  const [hasImageError, setHasImageError] = useState(false)
+
+  return (
+    <Card
+      className="gap-0 overflow-hidden rounded-control !p-0 shadow-[0_2px_8px_rgba(0,0,0,0.05)]"
+      onClick={onClick ? () => onClick(product.productId) : undefined}
+    >
+      <div className="h-[159px] overflow-hidden rounded-t-control bg-primary-100">
+        {hasImageError ? (
+          <div className="flex h-full w-full items-center justify-center bg-linear-to-br from-primary-100 to-primary-300 px-4 text-center text-sm font-semibold text-white">
+            가치가게
+          </div>
+        ) : (
+          <img
+            src={product.imageUrl}
+            alt={product.name}
+            className="h-full w-full object-cover"
+            onError={() => setHasImageError(true)}
+          />
+        )}
+      </div>
+
+      <div className="bg-white px-3 py-[14px]">
+        <div className="flex flex-col gap-[10px]">
+          <div className="flex flex-col gap-[2px]">
+            <p className="line-clamp-2 text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-700">
+              {product.name}
+            </p>
+            <div className="flex items-center gap-2">
+              <p
+                className={`text-base leading-[120%] font-semibold tracking-[-0.02em] ${
+                  product.soldOut ? 'text-gray-400 line-through' : 'text-gray-700'
+                }`}
+              >
+                {formatPrice(product.price)}
+              </p>
+              {product.soldOut ? (
+                <span className="text-sm leading-[120%] font-semibold tracking-[-0.02em] text-error">
+                  품절
+                </span>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-1">
+            <Badge tone="primary" className="px-[6px] py-[2px] text-xs font-medium tracking-[-0.02em]">
+              {product.category}
+            </Badge>
+          </div>
+        </div>
+      </div>
+    </Card>
+  )
+}

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -125,7 +125,7 @@ export function HomePage() {
               descriptionItems={['기부', '가치가게', '봉사']}
               variant="primary"
               size="lg"
-              onClick={() => navigate(ROUTE_PATHS.activitySocial)}
+              onClick={() => navigate(ROUTE_PATHS.activitySocialDonation)}
             />
 
             <div className="grid grid-cols-2 gap-4">

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -7,6 +7,7 @@ import { DonationDetailPage } from '../pages/activities/DonationDetailPage'
 import { DonationPage } from '../pages/activities/DonationPage'
 import { EnvironmentPage } from '../pages/activities/EnvironmentPage'
 import { SocialPage } from '../pages/activities/SocialPage'
+import { ValueStorePage } from '../pages/activities/ValueStorePage'
 import { LoginPage } from '../pages/auth/LoginPage'
 import { OnboardingPage } from '../pages/auth/OnboardingPage'
 import { SignupPage } from '../pages/auth/SignupPage'
@@ -52,6 +53,10 @@ export function AppRouter() {
           <Route
             path={ROUTE_PATHS.activitySocialDonation}
             element={<DonationPage />}
+          />
+          <Route
+            path={ROUTE_PATHS.activitySocialStore}
+            element={<ValueStorePage />}
           />
           <Route
             path={ROUTE_PATHS.donationDetail}

--- a/src/services/productService.ts
+++ b/src/services/productService.ts
@@ -1,0 +1,7 @@
+import { apiClient } from './apiClient'
+import type { ValueStoreProductListResponse } from '../types/product'
+
+export const getValueStoreProducts = async (): Promise<ValueStoreProductListResponse> => {
+  const response = await apiClient.get<ValueStoreProductListResponse>('/v1/esg/s/products')
+  return response.data
+}

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -1,0 +1,14 @@
+export interface ValueStoreProduct {
+  productId: number
+  name: string
+  category: string
+  price: number
+  imageUrl: string
+  description: string
+  stock: number
+  soldOut: boolean
+}
+
+export interface ValueStoreProductListResponse {
+  products: ValueStoreProduct[]
+}


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이슈 번호를 적어주세요. 머지 시 자동으로 이슈가 닫힙니다. -->
Closes #22 

## 📌 작업 내용
<!-- 어떤 작업을 했는지 간단히 설명 -->
- 가치가게 상품 목록 조회 API 및 응답 타입을 추가했습니다.
- S활동 내 가치가게 탭 화면과 상품 카드 UI를 구현했습니다.
- 품절 상품 가격 취소선 및 품절 문구 표시를 반영했습니다.
- 홈의 S 활동하기 버튼과 S활동 목록 페이지 뒤로가기 경로를 수정했습니다.
- S활동 탭 고정 및 페이지 전환 시 레이아웃 흔들림을 보정했습니다.


## 🛠 변경 사항
<!-- 주요 변경 파일이나 로직을 설명 -->

## ✅ 테스트 결과
<!-- 테스트를 어떻게 했는지 (로컬 실행, API 테스트 등) -->
- [x] 로컬에서 정상 동작 확인
- [x] API 테스트 완료 (해당되면)
- [x] 빌드 에러 없음

## 📸 스크린샷
<!-- UI 변경이 있으면 스크린샷 첨부 -->

## 💡 리뷰어에게
<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분 -->
