### PR TITLE
메인 대시보드 실데이터 연동

### DIFF
--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -10,17 +10,31 @@ import {
 import { getS3AssetUrl } from '../../constants/assetUrls'
 import { ROUTE_PATHS } from '../../constants/routePaths'
 import { useAuth } from '../../hooks/useAuth'
+import type { WeeklyActivityStatus } from '../../types/home'
 import type { UserGrade } from '../../types/user'
 import { DashboardActionTile } from './components/DashboardActionTile'
 import { WeeklyActivityTracker } from './components/WeeklyActivityTracker'
-import {
-  defaultGradeProgress,
-  defaultPoints,
-  gradeLabelMap,
-  weeklyActivityStatuses,
-} from './homeDashboardData'
+import { useHomeDashboardSummary } from './hooks/useHomeDashboardSummary'
 
 const numberFormatter = new Intl.NumberFormat('ko-KR')
+
+const gradeLabelMap: Record<UserGrade, string> = {
+  SEED: '씨앗',
+  SPROUT: '새싹',
+  TREE: '나무',
+  FOREST: '숲',
+  EARTH: '지구',
+}
+
+const emptyWeeklyActivities: WeeklyActivityStatus[] = [
+  { day: '월', completed: false },
+  { day: '화', completed: false },
+  { day: '수', completed: false },
+  { day: '목', completed: false },
+  { day: '금', completed: false },
+  { day: '토', completed: false },
+  { day: '일', completed: false },
+]
 
 function getGradeLabel(grade?: UserGrade | null) {
   if (!grade) {
@@ -30,16 +44,40 @@ function getGradeLabel(grade?: UserGrade | null) {
   return gradeLabelMap[grade]
 }
 
+function getCurrentWeekRangeLabel() {
+  const today = new Date()
+  const day = today.getDay()
+  const diffToMonday = day === 0 ? -6 : 1 - day
+
+  const startDate = new Date(today)
+  startDate.setDate(today.getDate() + diffToMonday)
+
+  const endDate = new Date(startDate)
+  endDate.setDate(startDate.getDate() + 6)
+
+  const format = (date: Date) => `${date.getMonth() + 1}/${date.getDate()}`
+
+  return `${format(startDate)} - ${format(endDate)}`
+}
+
 export function HomePage() {
   const location = useLocation()
   const navigate = useNavigate()
   const { user } = useAuth()
+  const { summary } = useHomeDashboardSummary()
 
-  const userName = user?.name ?? '000'
-  const gradeLabel = getGradeLabel(user?.currentGrade)
-  const totalPoints = user?.totalPoints ?? defaultPoints
+  const userName = summary?.name ?? user?.name ?? '000'
+  const gradeLabel = getGradeLabel(summary?.currentGrade ?? user?.currentGrade)
+  const totalPoints = summary?.totalPoints ?? user?.totalPoints ?? 0
   const formattedPoints = `${numberFormatter.format(totalPoints)}p`
   const headerLogo = getS3AssetUrl('logo.webp')
+  const weekRangeLabel = getCurrentWeekRangeLabel()
+  const gradeProgress = summary?.gradeProgress ?? {
+    current: 0,
+    target: 600,
+    visualValue: 0,
+  }
+  const weeklyActivities = summary?.weeklyActivities ?? emptyWeeklyActivities
 
   const handleBottomNavigation = (key: string) => {
     const nextPath =
@@ -63,12 +101,6 @@ export function HomePage() {
                 icon={<Icons.Chat size={22} />}
                 size="sm"
                 onClick={() => navigate(ROUTE_PATHS.chatbot)}
-              />
-              <IconButton
-                label="메뉴 열기"
-                icon={<Icons.Menu size={22} />}
-                size="sm"
-                onClick={() => undefined}
               />
             </div>
           }
@@ -106,11 +138,11 @@ export function HomePage() {
                 }
                 right={
                   <span className="text-xs font-medium text-gray-400">
-                    {defaultGradeProgress.current} / {defaultGradeProgress.target}
+                    {gradeProgress.current} / {gradeProgress.target}
                   </span>
                 }
               />
-              <ProgressBar value={defaultGradeProgress.visualValue} max={100} />
+              <ProgressBar value={gradeProgress.visualValue} max={100} />
               <div className="h-px w-full bg-gray-100" />
               <InfoRow
                 label={<span className="text-base font-medium text-gray-500">보유 포인트</span>}
@@ -149,9 +181,9 @@ export function HomePage() {
             <div className="space-y-4">
               <SectionHeader
                 title={<span className="text-base font-semibold text-gray-700">이번주 나의 활동</span>}
-                right={<span className="text-xs font-medium text-gray-400">3/21 - 3/27</span>}
+                right={<span className="text-xs font-medium text-gray-400">{weekRangeLabel}</span>}
               />
-              <WeeklyActivityTracker items={weeklyActivityStatuses} />
+              <WeeklyActivityTracker items={weeklyActivities} />
             </div>
           </Card>
 

--- a/src/pages/home/components/WeeklyActivityTracker.tsx
+++ b/src/pages/home/components/WeeklyActivityTracker.tsx
@@ -1,4 +1,4 @@
-import type { WeeklyActivityStatus } from '../homeDashboardData'
+import type { WeeklyActivityStatus } from '../../../types/home'
 
 interface WeeklyActivityTrackerProps {
   items: WeeklyActivityStatus[]

--- a/src/pages/home/hooks/useHomeDashboardSummary.ts
+++ b/src/pages/home/hooks/useHomeDashboardSummary.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react'
+import { getHomeDashboardSummary } from '../../../services/homeService'
+import type { HomeDashboardSummary } from '../../../types/home'
+
+export const useHomeDashboardSummary = () => {
+  const [summary, setSummary] = useState<HomeDashboardSummary | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    let isMounted = true
+
+    const fetchSummary = async () => {
+      setIsLoading(true)
+
+      try {
+        const response = await getHomeDashboardSummary()
+        if (!isMounted) {
+          return
+        }
+        setSummary(response)
+      } catch (error) {
+        console.error(error)
+        if (!isMounted) {
+          return
+        }
+        setSummary(null)
+      } finally {
+        if (isMounted) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    void fetchSummary()
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  return {
+    summary,
+    isLoading,
+  }
+}

--- a/src/services/homeService.ts
+++ b/src/services/homeService.ts
@@ -1,0 +1,7 @@
+import { apiClient } from './apiClient'
+import type { HomeDashboardSummary } from '../types/home'
+
+export const getHomeDashboardSummary = async (): Promise<HomeDashboardSummary> => {
+  const response = await apiClient.get<HomeDashboardSummary>('/home/summary')
+  return response.data
+}

--- a/src/types/home.ts
+++ b/src/types/home.ts
@@ -1,0 +1,20 @@
+import type { UserGrade } from './user'
+
+export interface GradeProgress {
+  current: number
+  target: number
+  visualValue: number
+}
+
+export interface WeeklyActivityStatus {
+  day: string
+  completed: boolean
+}
+
+export interface HomeDashboardSummary {
+  name: string
+  currentGrade: UserGrade
+  totalPoints: number
+  gradeProgress: GradeProgress
+  weeklyActivities: WeeklyActivityStatus[]
+}


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이슈 번호를 적어주세요. 머지 시 자동으로 이슈가 닫힙니다. -->
Closes #37

## 📌 작업 내용
<!-- 어떤 작업을 했는지 간단히 설명 -->
- 메인 대시보드의 mock 데이터를 실제 API 데이터 연동
- 메인 대시보드에서 현재 주 기준 활동 데이터와 사용자 등급 정보 표시

## 🛠 변경 사항
<!-- 주요 변경 파일이나 로직을 설명 -->
- homeService, home 타입, useHomeDashboardSummary 훅 추가
- HomePage에서 mock 데이터 의존을 제거하고 /home/summary 응답값 사용
- 주간 활동 영역은 현재 주 날짜 범위를 표시하고, 실데이터 기준 체크 상태 렌더링

## ✅ 테스트 결과
<!-- 테스트를 어떻게 했는지 (로컬 실행, API 테스트 등) -->
- [x] 로컬에서 정상 동작 확인
- [x] API 테스트 완료 (해당되면)
- [x] 빌드 에러 없음

## 📸 스크린샷
<!-- UI 변경이 있으면 스크린샷 첨부 -->

## 💡 리뷰어에게
<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분 -->
