### PR TITLE
[FEAT] 47 상품관 포트원 결제 및 결제 완료 구현

### DIFF
--- a/src/constants/routePaths.ts
+++ b/src/constants/routePaths.ts
@@ -21,6 +21,10 @@ export const ROUTE_PATHS = {
   activitySocialStore: '/esg/social/store',
   activitySocialProductDetail: '/esg/social/products/:productId',
   activitySocialProductPayment: '/esg/social/products/:productId/payment',
+  activitySocialProductPaymentCallback:
+    '/esg/social/products/:productId/payment/callback',
+  activitySocialProductPaymentComplete:
+    '/esg/social/products/:productId/payment/complete',
   donationDetail: '/esg/social/donations/:donationId',
   donationPayment: '/esg/social/donations/:donationId/payment',
   donationPaymentCallback: '/esg/social/donations/:donationId/payment/callback',
@@ -59,6 +63,14 @@ export const getValueStoreProductDetailPath = (productId: number | string) =>
 
 export const getValueStoreProductPaymentPath = (productId: number | string) =>
   `/esg/social/products/${productId}/payment`
+
+export const getValueStoreProductPaymentCallbackPath = (
+  productId: number | string,
+) => `/esg/social/products/${productId}/payment/callback`
+
+export const getValueStoreProductPaymentCompletePath = (
+  productId: number | string,
+) => `/esg/social/products/${productId}/payment/complete`
 
 export const getFinanceDetailPath = (productId: number | string) =>
   `/finance/${productId}`

--- a/src/pages/esg/social/DonationPage.tsx
+++ b/src/pages/esg/social/DonationPage.tsx
@@ -95,7 +95,7 @@ export function DonationPage() {
             <div className="h-28 animate-pulse rounded-control bg-primary-300" />
 
             <div className="space-y-4">
-              <div className="flex items-center justify-between px-3">
+              <div className="flex items-center justify-between px-[6px]">
                 <div className="h-5 w-28 animate-pulse rounded-full bg-gray-300" />
                 <div className="h-4 w-10 animate-pulse rounded-full bg-primary-100" />
               </div>
@@ -153,7 +153,7 @@ export function DonationPage() {
           />
 
           <section className="space-y-4">
-            <div className="flex items-center justify-between px-3">
+            <div className="flex items-center justify-between px-[6px]">
               <h2 className="text-lg leading-[120%] font-semibold text-font-main">
                 진행중인 캠페인
               </h2>

--- a/src/pages/esg/social/DonationPage.tsx
+++ b/src/pages/esg/social/DonationPage.tsx
@@ -61,6 +61,11 @@ export function DonationPage() {
       return
     }
 
+    if (key === 'benefits') {
+      navigate(ROUTE_PATHS.shop)
+      return
+    }
+
     if (key === 'finance') {
       navigate(ROUTE_PATHS.finance)
       return

--- a/src/pages/esg/social/ValueStoreDetailPage.tsx
+++ b/src/pages/esg/social/ValueStoreDetailPage.tsx
@@ -144,7 +144,7 @@ export function ValueStoreDetailPage() {
                   />
                 </section>
 
-                <section className="px-[31px] pt-8">
+                <section className="px-[24px] pt-6">
                   <div className="space-y-[22px]">
                     <div className="space-y-[12px]">
                       <Badge
@@ -180,7 +180,7 @@ export function ValueStoreDetailPage() {
 
                     <div className="h-px w-full bg-gray-300" />
 
-                    <div className="space-y-[11px] px-2">
+                    <div className="space-y-[11px]">
                       <h3 className="text-base leading-7 font-medium text-gray-800">
                         함께 나무를 심어주세요
                       </h3>

--- a/src/pages/esg/social/ValueStoreDetailPage.tsx
+++ b/src/pages/esg/social/ValueStoreDetailPage.tsx
@@ -155,9 +155,14 @@ export function ValueStoreDetailPage() {
                       </Badge>
 
                       <div className="space-y-4">
-                        <h2 className="w-[248px] text-[20px] leading-[120%] font-bold text-gray-500">
-                          {productDetail.name}
-                        </h2>
+                        <div className="space-y-[6px]">
+                          <p className="text-[12px] leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
+                            {productDetail.storeName}
+                          </p>
+                          <h2 className="w-[248px] text-[20px] leading-[120%] font-bold text-gray-500">
+                            {productDetail.name}
+                          </h2>
+                        </div>
 
                         <div className="flex items-center gap-2">
                           <p

--- a/src/pages/esg/social/ValueStorePage.tsx
+++ b/src/pages/esg/social/ValueStorePage.tsx
@@ -83,7 +83,7 @@ export function ValueStorePage() {
       {isLoading ? (
         <div className="flex flex-col gap-6">
           <section className="space-y-4 pt-2">
-            <div className="flex items-center justify-between px-3">
+            <div className="flex items-center justify-between px-[6px]">
               <div className="h-5 w-28 animate-pulse rounded-full bg-gray-300" />
               <div className="h-4 w-20 animate-pulse rounded-full bg-primary-100" />
             </div>
@@ -127,7 +127,7 @@ export function ValueStorePage() {
       {!isLoading && !error && productData ? (
         <div className="flex flex-col gap-6 pt-2">
           <section className="space-y-4">
-            <div className="flex items-center justify-between px-3">
+            <div className="flex items-center justify-between px-[6px]">
               <h2 className="text-lg leading-[120%] font-semibold text-gray-700">
                 판매중인 상품
               </h2>

--- a/src/pages/esg/social/ValueStorePage.tsx
+++ b/src/pages/esg/social/ValueStorePage.tsx
@@ -52,6 +52,11 @@ export function ValueStorePage() {
       return
     }
 
+    if (key === 'benefits') {
+      navigate(ROUTE_PATHS.shop)
+      return
+    }
+
     if (key === 'finance') {
       navigate(ROUTE_PATHS.finance)
       return

--- a/src/pages/esg/social/ValueStorePaymentCompletePage.tsx
+++ b/src/pages/esg/social/ValueStorePaymentCompletePage.tsx
@@ -1,0 +1,130 @@
+import { useLocation, useNavigate } from 'react-router-dom'
+import { Button } from '../../../components/common'
+import MainLayout from '../../../components/layout/MainLayout'
+import completeCharacterImage from '../../../assets/good.png'
+import { ROUTE_PATHS } from '../../../constants/routePaths'
+import type { VerifyProductPaymentResponse } from '../../../types/payment'
+
+interface ValueStorePaymentCompleteLocationState {
+  paymentResult?: VerifyProductPaymentResponse
+}
+
+const formatCurrency = (amount: number) =>
+  `${new Intl.NumberFormat('ko-KR').format(amount)}원`
+
+const formatPoint = (amount: number) =>
+  `${new Intl.NumberFormat('ko-KR').format(amount)}P`
+
+export function ValueStorePaymentCompletePage() {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const state =
+    location.state as ValueStorePaymentCompleteLocationState | undefined
+  const paymentResult = state?.paymentResult
+
+  return (
+    <MainLayout className="bg-gray-50">
+      <section className="mx-[-16px] my-[-24px] bg-gray-50 px-[31px] pt-[88px] pb-10">
+        {paymentResult ? (
+          <div className="flex flex-col">
+            <div className="flex flex-col items-center text-center">
+              <img
+                src={completeCharacterImage}
+                alt=""
+                className="h-[104px] w-[95px] object-cover"
+              />
+              <div className="mt-[11px] flex w-full flex-col items-center gap-2">
+                <h1 className="text-[20px] leading-[30px] font-bold tracking-[-0.02em] text-font-main">
+                  구매가 완료되었습니다!
+                </h1>
+                <p className="text-center text-[12px] leading-6 font-medium tracking-[-0.02em] text-font-sub">
+                  따뜻한 마음을 나누어 주셔서 감사합니다.
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-[23px] flex flex-1 flex-col">
+              <div className="rounded-card bg-white px-[15px] pt-[19px] pb-[18px] shadow-card">
+                <div className="text-left text-[12px] leading-6 font-bold tracking-[-0.02em] text-font-sub">
+                  구매내역 상세
+                </div>
+
+                <div className="mt-4 flex flex-col gap-[14px]">
+                  <div className="flex items-center justify-between gap-4">
+                    <span className="text-[12px] leading-6 font-medium tracking-[-0.02em] text-font-sub">
+                      상품명
+                    </span>
+                    <span className="text-right text-[16px] leading-6 font-semibold tracking-[-0.02em] text-font-sub">
+                      {paymentResult.productName}
+                    </span>
+                  </div>
+
+                  <div className="flex items-center justify-between gap-4">
+                    <span className="text-[12px] leading-6 font-medium tracking-[-0.02em] text-font-sub">
+                      결제 금액
+                    </span>
+                    <span className="text-right text-[16px] leading-6 font-semibold tracking-[-0.02em] text-font-sub">
+                      {formatCurrency(paymentResult.amount)}
+                    </span>
+                  </div>
+
+                  <div className="border-t border-gray-200" />
+
+                  <div className="flex flex-col gap-[11px]">
+                    <div className="flex items-center justify-between gap-4">
+                      <span className="text-[12px] leading-6 font-medium tracking-[-0.02em] text-font-sub">
+                        획득 ESG 포인트
+                      </span>
+                      <span className="text-right text-[16px] leading-6 font-semibold tracking-[-0.02em] text-primary-500">
+                        + {formatPoint(paymentResult.awardedPoint)}
+                      </span>
+                    </div>
+
+                    <p className="text-right text-[12px] leading-6 font-normal tracking-[-0.02em] text-gray-400">
+                      현재 보유 포인트 {formatPoint(paymentResult.currentPoint)}
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="mt-5">
+                <Button
+                  fullWidth
+                  size="md"
+                  onClick={() => navigate(ROUTE_PATHS.home, { replace: true })}
+                >
+                  메인으로 가기
+                </Button>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-col items-center justify-center text-center">
+            <div className="w-full rounded-card bg-white p-6 shadow-card">
+              <h2 className="text-[20px] leading-[30px] font-bold tracking-[-0.02em] text-font-main">
+                결제 완료 정보를 찾을 수 없어요
+              </h2>
+              <p className="mt-2 text-[12px] leading-6 font-medium tracking-[-0.02em] text-font-sub">
+                직접 진입한 경우일 수 있어요. 가치가게 목록으로 이동해 다시 시도해주세요.
+              </p>
+              <div className="mt-6">
+                <Button fullWidth onClick={() => navigate(ROUTE_PATHS.activitySocialStore)}>
+                  가치가게 목록으로 이동
+                </Button>
+              </div>
+            </div>
+            <div className="mt-6 w-full">
+              <Button
+                fullWidth
+                variant="primary"
+                onClick={() => navigate(ROUTE_PATHS.home, { replace: true })}
+              >
+                메인으로 가기
+              </Button>
+            </div>
+          </div>
+        )}
+      </section>
+    </MainLayout>
+  )
+}

--- a/src/pages/esg/social/ValueStorePaymentCompletePage.tsx
+++ b/src/pages/esg/social/ValueStorePaymentCompletePage.tsx
@@ -54,9 +54,14 @@ export function ValueStorePaymentCompletePage() {
                     <span className="text-[12px] leading-6 font-medium tracking-[-0.02em] text-font-sub">
                       상품명
                     </span>
-                    <span className="text-right text-[16px] leading-6 font-semibold tracking-[-0.02em] text-font-sub">
-                      {paymentResult.productName}
-                    </span>
+                    <div className="flex flex-col items-end gap-[2px] text-right">
+                      <span className="text-[12px] leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
+                        {paymentResult.storeName}
+                      </span>
+                      <span className="text-right text-[16px] leading-6 font-semibold tracking-[-0.02em] text-font-sub">
+                        {paymentResult.productName}
+                      </span>
+                    </div>
                   </div>
 
                   <div className="flex items-center justify-between gap-4">

--- a/src/pages/esg/social/ValueStorePaymentCompletePage.tsx
+++ b/src/pages/esg/social/ValueStorePaymentCompletePage.tsx
@@ -54,14 +54,9 @@ export function ValueStorePaymentCompletePage() {
                     <span className="text-[12px] leading-6 font-medium tracking-[-0.02em] text-font-sub">
                       상품명
                     </span>
-                    <div className="flex flex-col items-end gap-[2px] text-right">
-                      <span className="text-[12px] leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
-                        {paymentResult.storeName}
-                      </span>
-                      <span className="text-right text-[16px] leading-6 font-semibold tracking-[-0.02em] text-font-sub">
-                        {paymentResult.productName}
-                      </span>
-                    </div>
+                    <span className="text-right text-[16px] leading-6 font-semibold tracking-[-0.02em] text-font-sub">
+                      {paymentResult.productName}
+                    </span>
                   </div>
 
                   <div className="flex items-center justify-between gap-4">

--- a/src/pages/esg/social/ValueStorePaymentPage.tsx
+++ b/src/pages/esg/social/ValueStorePaymentPage.tsx
@@ -282,7 +282,7 @@ export function ValueStorePaymentPage() {
             </Card>
 
             <div className="space-y-[10px]">
-              <h3 className="text-[18px] leading-[120%] font-semibold tracking-[-0.02em] text-font-main">
+              <h3 className="text-base leading-7 font-semibold text-gray-800">
                 배송지 정보
               </h3>
               <Card className="rounded-control !p-5 shadow-[0_2px_8px_rgba(0,0,0,0.05)]">
@@ -361,7 +361,7 @@ export function ValueStorePaymentPage() {
           </div>
         ) : (
           <div className="space-y-[10px]">
-            <h3 className="text-[18px] leading-[120%] font-semibold tracking-[-0.02em] text-font-main">
+            <h3 className="text-base leading-7 font-semibold text-gray-800">
               배송지 정보
             </h3>
             <Card className="rounded-control !p-5 shadow-[0_2px_8px_rgba(0,0,0,0.05)]">

--- a/src/pages/esg/social/ValueStorePaymentPage.tsx
+++ b/src/pages/esg/social/ValueStorePaymentPage.tsx
@@ -12,11 +12,14 @@ import Header from '../../../components/layout/Header'
 import MainLayout from '../../../components/layout/MainLayout'
 import {
   ROUTE_PATHS,
+  getValueStoreProductPaymentCallbackPath,
   getValueStoreProductDetailPath,
 } from '../../../constants/routePaths'
 import { useAuth } from '../../../hooks/useAuth'
 import { getValueStoreProductDetail } from '../../../services/productService'
-import { prepareProductPayment } from '../../../services/paymentService'
+import {
+  prepareProductPayment,
+} from '../../../services/paymentService'
 import { getMyProfile } from '../../../services/userService'
 import {
   PortOnePaymentError,
@@ -160,6 +163,9 @@ export function ValueStorePaymentPage() {
         productName: preparedPayment.productName,
         amount: preparedPayment.amount,
         paymentMethod,
+        redirectUrl: `${window.location.origin}${getValueStoreProductPaymentCallbackPath(
+          preparedPayment.productId,
+        )}`,
       })
 
       console.info('포트원 상품 결제 성공 콜백', {
@@ -167,6 +173,25 @@ export function ValueStorePaymentPage() {
         merchant_uid: paymentResponse.merchant_uid,
         response: paymentResponse,
       })
+
+      if (!paymentResponse.imp_uid || !paymentResponse.merchant_uid) {
+        throw new Error('결제 검증에 필요한 정보가 누락되었어요.')
+      }
+
+      const callbackSearchParams = new URLSearchParams({
+        imp_uid: paymentResponse.imp_uid,
+        merchant_uid: paymentResponse.merchant_uid,
+        imp_success: 'true',
+      })
+
+      navigate(
+        `${getValueStoreProductPaymentCallbackPath(
+          preparedPayment.productId,
+        )}?${callbackSearchParams.toString()}`,
+        {
+          replace: true,
+        },
+      )
     } catch (error) {
       if (error instanceof PortOnePaymentError) {
         console.error('포트원 상품 결제 실패 콜백', {
@@ -437,10 +462,16 @@ export function ValueStorePaymentPage() {
           <div className="px-5 pt-[15px] pb-[calc(20px+env(safe-area-inset-bottom))]">
             <Button
               fullWidth
-              disabled={isLoading || !productDetail || isSubmittingPayment}
+              disabled={
+                isLoading ||
+                !productDetail ||
+                isSubmittingPayment
+              }
               onClick={() => void handlePayment()}
             >
-              {isSubmittingPayment ? '결제 준비 중...' : '구매하기'}
+              {isSubmittingPayment
+                ? '결제 준비 중...'
+                : '구매하기'}
             </Button>
           </div>
         </section>

--- a/src/pages/esg/social/ValueStorePaymentPage.tsx
+++ b/src/pages/esg/social/ValueStorePaymentPage.tsx
@@ -323,7 +323,7 @@ export function ValueStorePaymentPage() {
               </Card>
             </div>
 
-            <div className="space-y-[6px]">
+            <div className="space-y-[6px] pb-8">
               <h3 className="text-base leading-7 font-semibold text-gray-800">
                 결제 수단
               </h3>
@@ -401,7 +401,7 @@ export function ValueStorePaymentPage() {
               </div>
             </Card>
 
-            <div className="space-y-[6px]">
+            <div className="space-y-[6px] pb-8">
               <h3 className="text-base leading-7 font-semibold text-gray-800">
                 결제 수단
               </h3>

--- a/src/pages/esg/social/ValueStorePaymentPage.tsx
+++ b/src/pages/esg/social/ValueStorePaymentPage.tsx
@@ -272,7 +272,7 @@ export function ValueStorePaymentPage() {
                     <p className="text-[12px] leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
                       {productDetail.storeName}
                     </p>
-                    <h2 className="text-[16px] leading-[120%] font-medium tracking-[-0.02em] text-font-sub">
+                    <h2 className="text-[16px] leading-[120%] font-medium tracking-[-0.02em] text-gray-600">
                       {productDetail.name}
                     </h2>
                   </div>

--- a/src/pages/esg/social/ValueStorePaymentPage.tsx
+++ b/src/pages/esg/social/ValueStorePaymentPage.tsx
@@ -266,9 +266,14 @@ export function ValueStorePaymentPage() {
                 </div>
 
                 <div className="flex min-w-0 flex-1 flex-col gap-4">
-                  <h2 className="text-[16px] leading-[120%] font-medium tracking-[-0.02em] text-font-sub">
-                    {productDetail.name}
-                  </h2>
+                  <div className="flex flex-col gap-[6px]">
+                    <p className="text-[12px] leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
+                      {productDetail.storeName}
+                    </p>
+                    <h2 className="text-[16px] leading-[120%] font-medium tracking-[-0.02em] text-font-sub">
+                      {productDetail.name}
+                    </h2>
+                  </div>
                   <p className="text-[18px] leading-[120%] font-medium tracking-[-0.02em] text-font-main">
                     {formatPrice(productDetail.price)}
                   </p>

--- a/src/pages/esg/social/ValueStorePaymentPage.tsx
+++ b/src/pages/esg/social/ValueStorePaymentPage.tsx
@@ -16,7 +16,12 @@ import {
 } from '../../../constants/routePaths'
 import { useAuth } from '../../../hooks/useAuth'
 import { getValueStoreProductDetail } from '../../../services/productService'
+import { prepareProductPayment } from '../../../services/paymentService'
 import { getMyProfile } from '../../../services/userService'
+import {
+  PortOnePaymentError,
+  requestProductPortOnePayment,
+} from '../../../services/portoneService'
 import type { ValueStoreProductDetail } from '../../../types/product'
 import type { UserProfileResponse } from '../../../types/user'
 
@@ -61,11 +66,14 @@ export function ValueStorePaymentPage() {
   )
   const [isLoading, setIsLoading] = useState(true)
   const [paymentMethod, setPaymentMethod] = useState<'solpay' | 'card'>('card')
+  const [isSubmittingPayment, setIsSubmittingPayment] = useState(false)
+  const [paymentError, setPaymentError] = useState('')
+  const [preparedAmount, setPreparedAmount] = useState<number | null>(null)
   const deliveryName = userProfile?.name ?? user?.name ?? 'user'
   const deliveryPhoneNumber = userProfile?.phoneNumber ?? 'phoneNumber'
   const deliveryAddress =
     '서울특별시 영등포구 선유서로25길 34 (양평동2가, 삼성코코빌) 404호'
-  const finalAmount = productDetail?.price ?? 0
+  const finalAmount = preparedAmount ?? productDetail?.price ?? 0
   const expectedPoint = Math.floor(finalAmount * 0.01)
 
   const fetchProductDetail = useCallback(async () => {
@@ -130,6 +138,51 @@ export function ValueStorePaymentPage() {
     }
 
     navigate(ROUTE_PATHS.activitySocialStore)
+  }
+
+  const handlePayment = async () => {
+    if (!productDetail || isSubmittingPayment) {
+      return
+    }
+
+    setIsSubmittingPayment(true)
+    setPaymentError('')
+
+    try {
+      const preparedPayment = await prepareProductPayment({
+        productId: productDetail.productId,
+      })
+
+      setPreparedAmount(preparedPayment.amount)
+
+      const paymentResponse = await requestProductPortOnePayment({
+        merchantUid: preparedPayment.merchantUid,
+        productName: preparedPayment.productName,
+        amount: preparedPayment.amount,
+        paymentMethod,
+      })
+
+      console.info('포트원 상품 결제 성공 콜백', {
+        imp_uid: paymentResponse.imp_uid,
+        merchant_uid: paymentResponse.merchant_uid,
+        response: paymentResponse,
+      })
+    } catch (error) {
+      if (error instanceof PortOnePaymentError) {
+        console.error('포트원 상품 결제 실패 콜백', {
+          imp_uid: error.response.imp_uid,
+          merchant_uid: error.response.merchant_uid,
+          response: error.response,
+        })
+        window.alert(error.response.error_msg ?? '결제가 완료되지 않았어요.')
+      } else {
+        console.error('상품 결제 준비 실패', error)
+        setPaymentError('결제 준비에 실패했어요. 잠시 후 다시 시도해주세요.')
+        window.alert('결제 준비에 실패했어요. 잠시 후 다시 시도해주세요.')
+      }
+    } finally {
+      setIsSubmittingPayment(false)
+    }
   }
 
   return (
@@ -377,8 +430,18 @@ export function ValueStorePaymentPage() {
             </p>
           </div>
 
+          {paymentError ? (
+            <p className="px-5 pt-1 text-xs text-red-500">{paymentError}</p>
+          ) : null}
+
           <div className="px-5 pt-[15px] pb-[calc(20px+env(safe-area-inset-bottom))]">
-            <Button fullWidth>구매하기</Button>
+            <Button
+              fullWidth
+              disabled={isLoading || !productDetail || isSubmittingPayment}
+              onClick={() => void handlePayment()}
+            >
+              {isSubmittingPayment ? '결제 준비 중...' : '구매하기'}
+            </Button>
           </div>
         </section>
       </div>

--- a/src/pages/esg/social/ValueStorePaymentPage.tsx
+++ b/src/pages/esg/social/ValueStorePaymentPage.tsx
@@ -163,6 +163,8 @@ export function ValueStorePaymentPage() {
         productName: preparedPayment.productName,
         amount: preparedPayment.amount,
         paymentMethod,
+        buyerName: deliveryName,
+        buyerTel: deliveryPhoneNumber,
         redirectUrl: `${window.location.origin}${getValueStoreProductPaymentCallbackPath(
           preparedPayment.productId,
         )}`,

--- a/src/pages/esg/social/ValueStorePaymentRedirectPage.tsx
+++ b/src/pages/esg/social/ValueStorePaymentRedirectPage.tsx
@@ -1,0 +1,124 @@
+import { isAxiosError } from 'axios'
+import { useEffect, useState } from 'react'
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
+import MainLayout from '../../../components/layout/MainLayout'
+import { getValueStoreProductPaymentCompletePath } from '../../../constants/routePaths'
+import { verifyProductPayment } from '../../../services/paymentService'
+
+export function ValueStorePaymentRedirectPage() {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const { productId } = useParams()
+  const parsedProductId = Number(productId)
+  const [error, setError] = useState('')
+  const searchParams = new URLSearchParams(location.search)
+  const impUid = searchParams.get('imp_uid')
+  const merchantUid = searchParams.get('merchant_uid')
+  const impSuccess = searchParams.get('imp_success')
+  const success = searchParams.get('success')
+  const immediateError =
+    !Number.isInteger(parsedProductId) || parsedProductId <= 0
+      ? '올바른 결제 정보가 아니에요.'
+      : impSuccess === 'false' || success === 'false'
+        ? '결제가 완료되지 않았어요. 다시 시도해주세요.'
+        : !impUid || !merchantUid
+          ? '결제 검증에 필요한 정보가 없어요.'
+          : ''
+  const verificationKey =
+    !immediateError && impUid && merchantUid
+      ? `product-payment-verify:${parsedProductId}:${impUid}:${merchantUid}`
+      : ''
+  const currentMessage = immediateError || error
+  const title = currentMessage
+    ? '결제 확인 중 문제가 발생했어요'
+    : '결제 정보를 확인하고 있어요'
+  const description = currentMessage || '잠시만 기다려주세요.'
+
+  useEffect(() => {
+    if (immediateError || !impUid || !merchantUid) {
+      return
+    }
+
+    if (verificationKey && sessionStorage.getItem(verificationKey)) {
+      return
+    }
+
+    const verifyPayment = async () => {
+      const payload = {
+        productId: parsedProductId,
+        impUid,
+        merchantUid,
+      }
+
+      try {
+        if (verificationKey) {
+          sessionStorage.setItem(verificationKey, 'pending')
+        }
+
+        const paymentResult = await verifyProductPayment(payload)
+
+        if (verificationKey) {
+          sessionStorage.setItem(verificationKey, 'done')
+        }
+
+        navigate(getValueStoreProductPaymentCompletePath(parsedProductId), {
+          replace: true,
+          state: {
+            paymentResult,
+          },
+        })
+      } catch (verifyError) {
+        if (isAxiosError(verifyError)) {
+          console.error('상품 결제 리디렉션 검증 실패', {
+            requestPayload: payload,
+            status: verifyError.response?.status,
+            responseBody: verifyError.response?.data,
+            message: verifyError.message,
+          })
+        } else {
+          console.error('상품 결제 리디렉션 검증 실패', {
+            requestPayload: payload,
+            error: verifyError,
+          })
+        }
+
+        if (verificationKey) {
+          sessionStorage.removeItem(verificationKey)
+        }
+
+        setError('결제 검증에 실패했어요. 잠시 후 다시 시도해주세요.')
+      }
+    }
+
+    void verifyPayment()
+  }, [
+    immediateError,
+    impUid,
+    merchantUid,
+    navigate,
+    parsedProductId,
+    verificationKey,
+  ])
+
+  return (
+    <MainLayout className="bg-white">
+      <section className="mx-[-16px] flex min-h-[calc(100vh-48px)] items-center justify-center bg-white px-8">
+        <div className="flex w-full max-w-[320px] flex-col items-center justify-center text-center">
+          <div className="space-y-3">
+            <h2 className="text-[22px] leading-[140%] font-semibold tracking-[-0.02em] text-font-main">
+              {title}
+            </h2>
+            <p className="text-[15px] leading-[160%] font-normal tracking-[-0.02em] text-font-sub">
+              {description}
+            </p>
+          </div>
+
+          <div
+            className="mt-8 h-10 w-10 animate-spin rounded-full border-[3px] border-gray-200 border-t-primary-500"
+            aria-label="결제 확인 중"
+          />
+        </div>
+      </section>
+    </MainLayout>
+  )
+}

--- a/src/pages/esg/social/components/DonationCampaignCard.tsx
+++ b/src/pages/esg/social/components/DonationCampaignCard.tsx
@@ -21,11 +21,11 @@ export const DonationCampaignCard = ({
 
   return (
     <Card
-      className="h-[151px] gap-0 overflow-hidden rounded-control !p-4 shadow-[0_2px_8px_rgba(0,0,0,0.05)]"
+      className="h-[151px] gap-0 overflow-hidden rounded-control !p-4 shadow-[0_2px_8px_rgba(0,0,0,0.05)] max-[380px]:h-auto"
       onClick={onClick}
     >
-      <div className="flex h-full items-center gap-4">
-        <div className="h-[119px] w-[119px] shrink-0 overflow-hidden rounded-[4px] bg-white">
+      <div className="flex h-full items-center gap-4 max-[380px]:items-start max-[380px]:gap-3">
+        <div className="h-[119px] w-[119px] shrink-0 overflow-hidden rounded-[4px] bg-white max-[380px]:h-[96px] max-[380px]:w-[96px]">
           {hasImageError ? (
             <div className="flex h-full w-full items-center justify-center bg-linear-to-br from-primary-200 to-primary-500 px-4 text-center text-xs font-semibold leading-[120%] text-white">
               SOLve
@@ -40,17 +40,17 @@ export const DonationCampaignCard = ({
           )}
         </div>
 
-        <div className="flex h-full min-w-0 flex-1 flex-col justify-center gap-5">
+        <div className="flex h-full min-w-0 flex-1 flex-col justify-center gap-5 max-[380px]:justify-between max-[380px]:gap-3">
           <div className="flex flex-col gap-1">
             <p className="text-xs leading-[120%] font-semibold text-primary-400">
               {formatNumber(donation.participantCount)}명 참여
             </p>
 
-            <div className="flex h-[38px] flex-col justify-center gap-[2px]">
-              <h2 className="text-base leading-[120%] font-bold tracking-[-0.02em] text-font-main">
+            <div className="flex h-[38px] flex-col justify-center gap-[2px] max-[380px]:h-auto max-[380px]:min-h-[38px]">
+              <h2 className="text-base leading-[120%] font-bold tracking-[-0.02em] text-font-main max-[380px]:line-clamp-2">
                 {donation.name}
               </h2>
-              <p className="text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-500">
+              <p className="text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-500 max-[380px]:line-clamp-2">
                 {donation.summary}
               </p>
             </div>
@@ -58,11 +58,11 @@ export const DonationCampaignCard = ({
 
           <div className="flex flex-col gap-2">
             <div className="flex items-center justify-between">
-              <p className="text-[10px] leading-[120%] font-medium tracking-[-0.03em] text-gray-400">
+              <p className="text-[10px] leading-[120%] font-medium tracking-[-0.03em] text-gray-400 max-[380px]:min-w-0 max-[380px]:pr-2">
                 {formatCurrency(donation.currentAmount)} /{' '}
                 {formatCurrency(donation.targetAmount)}
               </p>
-              <p className="text-[10px] leading-[120%] font-semibold tracking-[-0.01em] text-primary-400">
+              <p className="text-[10px] leading-[120%] font-semibold tracking-[-0.01em] text-primary-400 max-[380px]:shrink-0">
                 {donation.progressPercentage}%
               </p>
             </div>

--- a/src/pages/esg/social/components/DonationSummaryBanner.tsx
+++ b/src/pages/esg/social/components/DonationSummaryBanner.tsx
@@ -13,8 +13,8 @@ export const DonationSummaryBanner = ({
 }: DonationSummaryBannerProps) => {
   return (
     <section className="relative h-[112px] overflow-hidden rounded-control bg-primary-400">
-      <div className="absolute inset-y-0 left-6 flex w-[153px] flex-col justify-center gap-2">
-        <div className="flex w-[126px] flex-col gap-1">
+      <div className="absolute inset-y-0 left-6 flex w-[153px] flex-col justify-center gap-2 max-[380px]:left-5 max-[380px]:w-[calc(100%-150px)]">
+        <div className="flex w-[126px] flex-col gap-1 max-[380px]:w-full">
           <p className="text-sm leading-[120%] font-semibold text-primary-50">
             현재까지 모인 기부금
           </p>
@@ -33,7 +33,7 @@ export const DonationSummaryBanner = ({
           src={imageSrc}
           alt={imageAlt}
           aria-hidden={imageAlt ? undefined : true}
-          className="absolute right-3 top-1/2 h-[96px] w-[194px] -translate-y-1/2 object-contain object-right"
+          className="absolute right-3 top-1/2 h-[96px] w-[194px] -translate-y-1/2 object-contain object-right max-[380px]:right-2 max-[380px]:h-[88px] max-[380px]:w-[132px]"
         />
       ) : (
         <>

--- a/src/pages/esg/social/components/ValueStoreProductCard.tsx
+++ b/src/pages/esg/social/components/ValueStoreProductCard.tsx
@@ -39,6 +39,9 @@ export const ValueStoreProductCard = ({
       <div className="bg-white px-3 py-[14px]">
         <div className="flex flex-col gap-[10px]">
           <div className="flex flex-col gap-[2px]">
+            <p className="text-[12px] leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
+              {product.storeName}
+            </p>
             <div className="min-h-[34px]">
               <p className="line-clamp-2 text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-700">
                 {product.name}

--- a/src/pages/esg/social/components/ValueStoreProductCard.tsx
+++ b/src/pages/esg/social/components/ValueStoreProductCard.tsx
@@ -39,9 +39,11 @@ export const ValueStoreProductCard = ({
       <div className="bg-white px-3 py-[14px]">
         <div className="flex flex-col gap-[10px]">
           <div className="flex flex-col gap-[2px]">
-            <p className="line-clamp-2 text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-700">
-              {product.name}
-            </p>
+            <div className="min-h-[34px]">
+              <p className="line-clamp-2 text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-700">
+                {product.name}
+              </p>
+            </div>
             <div className="flex items-center gap-2">
               <p
                 className={`text-base leading-[120%] font-semibold tracking-[-0.02em] ${

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -17,7 +17,9 @@ import { DonationPaymentCompletePage } from '../pages/esg/social/DonationPayment
 import { DonationPage } from '../pages/esg/social/DonationPage'
 import { SocialPage } from '../pages/esg/social/SocialPage'
 import { ValueStoreDetailPage } from '../pages/esg/social/ValueStoreDetailPage'
+import { ValueStorePaymentCompletePage } from '../pages/esg/social/ValueStorePaymentCompletePage'
 import { ValueStorePaymentPage } from '../pages/esg/social/ValueStorePaymentPage'
+import { ValueStorePaymentRedirectPage } from '../pages/esg/social/ValueStorePaymentRedirectPage'
 import { ValueStorePage } from '../pages/esg/social/ValueStorePage'
 
 import { LoginPage } from '../pages/auth/LoginPage'
@@ -113,6 +115,14 @@ function AppRoutes() {
           <Route
             path={ROUTE_PATHS.activitySocialProductPayment}
             element={<ValueStorePaymentPage />}
+          />
+          <Route
+            path={ROUTE_PATHS.activitySocialProductPaymentCallback}
+            element={<ValueStorePaymentRedirectPage />}
+          />
+          <Route
+            path={ROUTE_PATHS.activitySocialProductPaymentComplete}
+            element={<ValueStorePaymentCompletePage />}
           />
 
           <Route

--- a/src/services/paymentService.ts
+++ b/src/services/paymentService.ts
@@ -2,6 +2,8 @@ import { apiClient } from './apiClient'
 import type {
   PrepareDonationPaymentRequest,
   PrepareDonationPaymentResponse,
+  PrepareProductPaymentRequest,
+  PrepareProductPaymentResponse,
   VerifyDonationPaymentRequest,
   VerifyDonationPaymentResponse,
 } from '../types/payment'
@@ -11,6 +13,17 @@ export const prepareDonationPayment = async (
 ): Promise<PrepareDonationPaymentResponse> => {
   const response = await apiClient.post<PrepareDonationPaymentResponse>(
     '/v1/payments/prepare',
+    payload,
+  )
+
+  return response.data
+}
+
+export const prepareProductPayment = async (
+  payload: PrepareProductPaymentRequest,
+): Promise<PrepareProductPaymentResponse> => {
+  const response = await apiClient.post<PrepareProductPaymentResponse>(
+    '/v1/payments/products/prepare',
     payload,
   )
 

--- a/src/services/paymentService.ts
+++ b/src/services/paymentService.ts
@@ -6,6 +6,8 @@ import type {
   PrepareProductPaymentResponse,
   VerifyDonationPaymentRequest,
   VerifyDonationPaymentResponse,
+  VerifyProductPaymentRequest,
+  VerifyProductPaymentResponse,
 } from '../types/payment'
 
 export const prepareDonationPayment = async (
@@ -35,6 +37,17 @@ export const verifyDonationPayment = async (
 ): Promise<VerifyDonationPaymentResponse> => {
   const response = await apiClient.post<VerifyDonationPaymentResponse>(
     '/v1/payments/verify',
+    payload,
+  )
+
+  return response.data
+}
+
+export const verifyProductPayment = async (
+  payload: VerifyProductPaymentRequest,
+): Promise<VerifyProductPaymentResponse> => {
+  const response = await apiClient.post<VerifyProductPaymentResponse>(
+    '/v1/payments/products/verify',
     payload,
   )
 

--- a/src/services/portoneService.ts
+++ b/src/services/portoneService.ts
@@ -61,6 +61,8 @@ export interface RequestDonationPortOnePaymentParams {
   donationName: string
   amount: number
   paymentMethod: 'solpay' | 'card'
+  buyerName?: string
+  buyerTel?: string
   redirectUrl?: string
 }
 
@@ -69,6 +71,8 @@ export interface RequestProductPortOnePaymentParams {
   productName: string
   amount: number
   paymentMethod: 'solpay' | 'card'
+  buyerName?: string
+  buyerTel?: string
   redirectUrl?: string
 }
 
@@ -87,6 +91,8 @@ const buildRequestParams = ({
   donationName,
   amount,
   paymentMethod,
+  buyerName,
+  buyerTel,
   redirectUrl,
 }: RequestDonationPortOnePaymentParams): PortOneRequestPayParams => {
   if (!PORTONE_CHANNEL_KEY) {
@@ -99,6 +105,8 @@ const buildRequestParams = ({
     merchant_uid: merchantUid,
     name: donationName,
     amount,
+    buyer_name: buyerName,
+    buyer_tel: buyerTel,
     m_redirect_url: redirectUrl,
   }
 }
@@ -126,6 +134,8 @@ export const requestProductPortOnePayment = async ({
   productName,
   amount,
   paymentMethod,
+  buyerName,
+  buyerTel,
   redirectUrl,
 }: RequestProductPortOnePaymentParams): Promise<PortOnePaymentResponse> => {
   const IMP = await getPortOne()
@@ -134,6 +144,8 @@ export const requestProductPortOnePayment = async ({
     donationName: productName,
     amount,
     paymentMethod,
+    buyerName,
+    buyerTel,
     redirectUrl,
   })
 

--- a/src/services/portoneService.ts
+++ b/src/services/portoneService.ts
@@ -64,6 +64,14 @@ export interface RequestDonationPortOnePaymentParams {
   redirectUrl?: string
 }
 
+export interface RequestProductPortOnePaymentParams {
+  merchantUid: string
+  productName: string
+  amount: number
+  paymentMethod: 'solpay' | 'card'
+  redirectUrl?: string
+}
+
 export class PortOnePaymentError extends Error {
   response: PortOnePaymentResponse
 
@@ -100,6 +108,34 @@ export const requestDonationPortOnePayment = async (
 ): Promise<PortOnePaymentResponse> => {
   const IMP = await getPortOne()
   const requestParams = buildRequestParams(params)
+
+  return new Promise<PortOnePaymentResponse>((resolve, reject) => {
+    IMP.request_pay(requestParams, (response) => {
+      if (response.success) {
+        resolve(response)
+        return
+      }
+
+      reject(new PortOnePaymentError(response))
+    })
+  })
+}
+
+export const requestProductPortOnePayment = async ({
+  merchantUid,
+  productName,
+  amount,
+  paymentMethod,
+  redirectUrl,
+}: RequestProductPortOnePaymentParams): Promise<PortOnePaymentResponse> => {
+  const IMP = await getPortOne()
+  const requestParams = buildRequestParams({
+    merchantUid,
+    donationName: productName,
+    amount,
+    paymentMethod,
+    redirectUrl,
+  })
 
   return new Promise<PortOnePaymentResponse>((resolve, reject) => {
     IMP.request_pay(requestParams, (response) => {

--- a/src/types/payment.ts
+++ b/src/types/payment.ts
@@ -25,3 +25,14 @@ export interface VerifyDonationPaymentResponse {
   awardedPoint: number
   currentPoint: number
 }
+
+export interface PrepareProductPaymentRequest {
+  productId: number
+}
+
+export interface PrepareProductPaymentResponse {
+  merchantUid: string
+  productId: number
+  productName: string
+  amount: number
+}

--- a/src/types/payment.ts
+++ b/src/types/payment.ts
@@ -33,6 +33,7 @@ export interface PrepareProductPaymentRequest {
 export interface PrepareProductPaymentResponse {
   merchantUid: string
   productId: number
+  storeName: string
   productName: string
   amount: number
 }
@@ -46,6 +47,7 @@ export interface VerifyProductPaymentRequest {
 export interface VerifyProductPaymentResponse {
   paymentId: number
   productId: number
+  storeName: string
   productName: string
   amount: number
   paymentStatus: 'paid' | string

--- a/src/types/payment.ts
+++ b/src/types/payment.ts
@@ -36,3 +36,19 @@ export interface PrepareProductPaymentResponse {
   productName: string
   amount: number
 }
+
+export interface VerifyProductPaymentRequest {
+  productId: number
+  impUid: string
+  merchantUid: string
+}
+
+export interface VerifyProductPaymentResponse {
+  paymentId: number
+  productId: number
+  productName: string
+  amount: number
+  paymentStatus: 'paid' | string
+  awardedPoint: number
+  currentPoint: number
+}

--- a/src/types/portone.d.ts
+++ b/src/types/portone.d.ts
@@ -4,6 +4,8 @@ export interface PortOneRequestPayParams {
   merchant_uid: string
   name: string
   amount: number
+  buyer_name?: string
+  buyer_tel?: string
   m_redirect_url?: string
 }
 

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -1,5 +1,6 @@
 export interface ValueStoreProduct {
   productId: number
+  storeName: string
   name: string
   category: string
   price: number


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이슈 번호를 적어주세요. 머지 시 자동으로 이슈가 닫힙니다. -->
Closes #47 

## 📌 작업 내용
<!-- 어떤 작업을 했는지 간단히 설명 -->
- 가치가게 상품 결제 페이지를 구현하고 상품 결제 준비/검증 API 및 포트원 결제 흐름을 연결했습니다.
- 상품 결제 완료 페이지와 결제 확인 페이지를 추가하고, 배송지 정보 및 결제 수단 UI를 구성했습니다.
- 가치가게 목록, 상품 상세, 상품 결제/완료 페이지에 기업명(storeName) 표시를 반영했습니다.
- S 활동 페이지에서 하단 포인트샵 탭 이동이 되지 않던 문제를 수정했습니다.

## 🛠 변경 사항
<!-- 주요 변경 파일이나 로직을 설명 -->
- src/pages/esg/social/ValueStorePaymentPage.tsx 에 상품 정보 카드, 배송지 정보 카드, 결제 수단, 최종 결제 금액, 예상 적립 포인트 UI를 구현하고 포트원 결제 호출 흐름을 연결했습니다.
- src/pages/esg/social/ValueStorePaymentRedirectPage.tsx 에 상품 결제 후 검증용 결제 확인 페이지를 추가했습니다.
- src/pages/esg/social/ValueStorePaymentCompletePage.tsx 에 상품 결제 완료 후 구매 내역과 포인트를 보여주는 완료 페이지를 구현했습니다.
- src/services/paymentService.ts 에 상품 결제 준비/검증 API 호출 로직을 추가했습니다.
- src/services/portoneService.ts 와 src/types/portone.d.ts 에 상품 결제 포트원 호출 파라미터와 주문자 정보 전달을 반영했습니다.
- src/types/payment.ts 와 src/types/product.ts 에 상품 결제 및 기업명 표시를 위한 응답 타입을 추가했습니다.
- src/routes/Router.tsx 와 src/constants/routePaths.ts 에 상품 결제, 결제 확인, 결제 완료 라우트를 추가했습니다.
- src/pages/esg/social/components/ValueStoreProductCard.tsx, src/pages/esg/social/ValueStoreDetailPage.tsx, src/pages/esg/social/ValueStorePaymentPage.tsx 에 storeName 표시를 추가했습니다.
- src/pages/esg/social/DonationPage.tsx 와 src/pages/esg/social/ValueStorePage.tsx 에서 S 활동 하단 포인트샵 탭 이동을 연결했습니다.



## ✅ 테스트 결과
<!-- 테스트를 어떻게 했는지 (로컬 실행, API 테스트 등) -->
- [ ] 로컬에서 정상 동작 확인
- [ ] API 테스트 완료 (해당되면)
- [ ] 빌드 에러 없음

## 📸 스크린샷
<!-- UI 변경이 있으면 스크린샷 첨부 -->

## 💡 리뷰어에게
<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분 -->
