### PR TITLE
49 feat 마이페이지   프로필 및 계정 관리 화면 구현

### DIFF
--- a/src/pages/auth/SignupAgreementPage.tsx
+++ b/src/pages/auth/SignupAgreementPage.tsx
@@ -81,6 +81,7 @@ export function SignupAgreementPage() {
       navigate(ROUTE_PATHS.signup, {
         state: {
           verificationToken: verifyResult.verificationToken,
+          preservedLoginId: verifyResult.preservedLoginId,
         },
       })
     } catch (error) {

--- a/src/pages/auth/SignupCompletePage.tsx
+++ b/src/pages/auth/SignupCompletePage.tsx
@@ -1,50 +1,47 @@
 ﻿import { useNavigate } from 'react-router-dom'
-import signupImage from '../../assets/signup.png'
-import { PageScaffold } from '../PageScaffold'
 import Button from '../../components/common/Button'
+import MainLayout from '../../components/layout/MainLayout'
+import { getS3AssetUrl } from '../../constants/assetUrls'
 import { ROUTE_PATHS } from '../../constants/routePaths'
 
 export function SignupCompletePage() {
   const navigate = useNavigate()
+  const completeImage = getS3AssetUrl('lulu.webp')
 
   return (
-    <div className="min-h-screen bg-white">
-      <PageScaffold title="" description="">
-        <div className="flex min-h-[calc(100vh-60px)] flex-col items-center px-6 pb-10 pt-16 text-center">
-          <div className="flex w-full flex-1 flex-col items-center justify-center">
-            <div className="mb-10">
-              <img
-                src={signupImage}
-                alt="회원가입 완료"
-                className="h-44 w-44 object-contain"
-              />
-            </div>
+    <MainLayout className="bg-white">
+      <div className="flex min-h-[calc(100vh-48px)] flex-col px-6 pb-32 pt-6 text-center">
+        <div className="flex flex-1 flex-col items-center justify-center">
+          <img
+            src={completeImage}
+            alt="회원가입 완료"
+            className="mb-3 h-44 w-44 object-contain"
+          />
 
-            <div className="flex flex-col items-center gap-4">
-              <h2 className="text-[26px] font-bold tracking-tight text-font-main">
-                회원가입 완료!
-              </h2>
-              <p className="text-[16px] leading-relaxed text-font-sub">
-                SOLve와 함께할 준비가 끝났어요.
-                <br />
-                로그인하고 서비스를 시작해보세요.
-              </p>
-            </div>
-          </div>
-
-          <div className="mt-auto w-full">
-            <Button
-              type="button"
-              variant="primary"
-              fullWidth
-              size="lg"
-              onClick={() => navigate(ROUTE_PATHS.login)}
-            >
-              로그인하러가기
-            </Button>
+          <div className="flex flex-col items-center gap-4">
+            <h2 className="text-[26px] font-bold tracking-tight text-font-main">
+              회원가입 완료!
+            </h2>
+            <p className="text-[16px] leading-relaxed text-font-sub">
+              SOLve와 함께할 준비가 끝났어요.
+              <br />
+              로그인하고 서비스를 시작해보세요.
+            </p>
           </div>
         </div>
-      </PageScaffold>
-    </div>
+
+        <div className="fixed bottom-0 left-1/2 z-10 w-full max-w-[600px] -translate-x-1/2 bg-white px-6 pb-4 pt-4">
+          <Button
+            type="button"
+            variant="primary"
+            fullWidth
+            size="lg"
+            onClick={() => navigate(ROUTE_PATHS.login)}
+          >
+            로그인하러가기
+          </Button>
+        </div>
+      </div>
+    </MainLayout>
   )
 }

--- a/src/pages/auth/SignupPage.tsx
+++ b/src/pages/auth/SignupPage.tsx
@@ -1,4 +1,4 @@
-﻿import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { AxiosError } from 'axios'
 import { authService } from '../../services/authService'
@@ -12,10 +12,14 @@ import { Icons } from '../../components/common/Icons'
 export function SignupPage() {
   const navigate = useNavigate()
   const location = useLocation()
-  const verificationState = location.state as { verificationToken?: string } | null
+  const verificationState = location.state as
+    | { verificationToken?: string; preservedLoginId?: string }
+    | null
+  const preservedLoginId = verificationState?.preservedLoginId?.trim() ?? ''
+  const isReactivationSignup = preservedLoginId.length > 0
 
   const [formData, setFormData] = useState<AuthJoinRequest>({
-    loginId: '',
+    loginId: preservedLoginId,
     password: '',
     name: '',
     email: '',
@@ -86,7 +90,7 @@ export function SignupPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
 
-    if (!isIdChecked) {
+    if (!isReactivationSignup && !isIdChecked) {
       alert('아이디 중복 확인을 먼저 진행해주세요.')
       return
     }
@@ -103,6 +107,7 @@ export function SignupPage() {
     try {
       const requestData = {
         ...formData,
+        loginId: isReactivationSignup ? preservedLoginId : formData.loginId,
         phoneNumber: formData.phoneNumber.trim(),
         ciDi: `DEV_${Date.now()}`,
         verificationToken: verificationState.verificationToken,
@@ -135,37 +140,48 @@ export function SignupPage() {
 
         <div>
           <h2 className="mb-2 text-base font-semibold text-font-main">기본 정보를 입력해주세요</h2>
-          <p className="text-xs text-font-sub">본인인증이 완료되었습니다. 회원가입 정보를 직접 입력해주세요.</p>
+          <p className="text-xs text-font-sub">
+            {isReactivationSignup
+              ? '재가입시 기존 아이디가 그대로 유지됩니다.'
+              : '본인인증이 완료되었습니다. 회원가입 정보를 직접 입력해주세요.'}
+          </p>
         </div>
 
         <form onSubmit={handleSubmit} className="flex flex-col gap-5">
-          <div className="flex flex-col">
-            <div className="flex items-start gap-2">
-              <div className="flex min-w-0 flex-1 flex-col">
-                <Input
-                  label="아이디"
-                  name="loginId"
-                  value={formData.loginId}
-                  onChange={handleChange}
-                  placeholder="아이디를 입력하세요"
-                  className="w-full"
-                  required
-                />
+          {isReactivationSignup ? (
+            <div className="rounded-control border border-primary-100 bg-primary-50 px-4 py-4">
+              <p className="text-xs font-medium text-primary-600">기존 아이디</p>
+              <p className="mt-1 text-sm font-semibold text-font-main">{preservedLoginId}</p>
+            </div>
+          ) : (
+            <div className="flex flex-col">
+              <div className="flex items-start gap-2">
+                <div className="flex min-w-0 flex-1 flex-col">
+                  <Input
+                    label="아이디"
+                    name="loginId"
+                    value={formData.loginId}
+                    onChange={handleChange}
+                    placeholder="아이디를 입력하세요"
+                    className="w-full"
+                    required
+                  />
 
-                {idCheckMessage && (
-                  <p className="mt-1.5 pr-0.5 text-right text-[11px] font-medium" style={{ color: idCheckColor }}>
-                    {idCheckColor === 'green' ? '✓' : '✕'} {idCheckMessage}
-                  </p>
-                )}
-              </div>
+                  {idCheckMessage && (
+                    <p className="mt-1.5 pr-0.5 text-right text-[11px] font-medium" style={{ color: idCheckColor }}>
+                      {idCheckColor === 'green' ? '✓' : '✕'} {idCheckMessage}
+                    </p>
+                  )}
+                </div>
 
-              <div className="shrink-0 pt-6">
-                <Button type="button" onClick={handleCheckId} variant="sub" className="w-[100px] text-sm">
-                  중복확인
-                </Button>
+                <div className="shrink-0 pt-6">
+                  <Button type="button" onClick={handleCheckId} variant="sub" className="w-[100px] text-sm">
+                    중복확인
+                  </Button>
+                </div>
               </div>
             </div>
-          </div>
+          )}
 
           <Input
             label="비밀번호"

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -10,7 +10,7 @@ import {
 import { ROUTE_PATHS } from '../../constants/routePaths'
 import { useAuth } from '../../hooks/useAuth'
 import { ShopHeader } from '../shop/components/ShopHeader'
-import { LogOut } from 'lucide-react'
+import { LogOut, Store } from 'lucide-react'
 
 const menuItems = [
   {
@@ -32,6 +32,18 @@ const menuItems = [
     path: ROUTE_PATHS.myHistory,
   },
   {
+    key: 'report',
+    label: 'ESG 활동 보고서',
+    icon: <FileChartColumn size={18} />,
+    path: ROUTE_PATHS.myReport,
+  },
+  {
+    key: 'storePurchase',
+    label: '가치가게 구매 내역',
+    icon: <Store size={18} />,
+    path: ROUTE_PATHS.activitySocialStore,
+  },
+  {
     key: 'finance',
     label: '금융 상품 관리',
     icon: <Landmark size={18} />,
@@ -43,17 +55,11 @@ const menuItems = [
     icon: <Coins size={18} />,
     path: ROUTE_PATHS.myPointManage,
   },
-  {
-    key: 'report',
-    label: 'ESG 활동 보고서',
-    icon: <FileChartColumn size={18} />,
-    path: ROUTE_PATHS.myReport,
-  },
 ]
 
 const accountMenuItems = menuItems.filter((item) => item.key === 'profile')
 const activityMenuItems = menuItems.filter((item) =>
-  ['grade', 'history', 'point', 'report'].includes(item.key),
+  ['grade', 'history', 'storePurchase', 'report', 'point'].includes(item.key),
 )
 const financeMenuItems = menuItems.filter((item) => item.key === 'finance')
 
@@ -141,9 +147,9 @@ export const MyPage = () => {
             <button
               type="button"
               onClick={handleLogout}
-              className="flex w-full items-center gap-3 px-5 py-5 text-left text-red-500"
+              className="flex w-full items-center gap-3 px-5 py-5 text-left text-primary-400"
             >
-              <div className="flex h-9 w-9 items-center justify-center rounded-full bg-red-50 text-red-400">
+              <div className="flex h-9 w-9 items-center justify-center rounded-full bg-gray-50 text-primary-400">
                 <LogOut size={18} />
               </div>
               <span className="text-[15px] font-medium">로그아웃</span>

--- a/src/pages/my/MyProfilePage.tsx
+++ b/src/pages/my/MyProfilePage.tsx
@@ -1,10 +1,665 @@
-import { PageScaffold } from '../PageScaffold'
+﻿import axios from 'axios'
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Badge, Button, Card, InfoRow, Input, SectionHeader } from '../../components/common'
+import BottomNavigation from '../../components/layout/BottomNavigation'
+import MainLayout from '../../components/layout/MainLayout'
+import {
+  BOTTOM_NAVIGATION_ITEMS,
+  BOTTOM_NAVIGATION_ROUTE_BY_KEY,
+} from '../../constants/bottomNavigation'
+import { getS3AssetUrl } from '../../constants/assetUrls'
+import { ROUTE_PATHS } from '../../constants/routePaths'
+import { identityVerificationService } from '../../services/identityVerificationService'
+import {
+  checkMyPassword,
+  getMyProfile,
+  updateMyEmail,
+  updateMyPassword,
+  updateMyPhoneNumber,
+  withdrawMyAccount,
+} from '../../services/userProfileService'
+import { useAuthStore } from '../../store/authStore'
+import { ShopHeader } from '../shop/components/ShopHeader'
+
+type EditableField = 'email' | 'phone'
+
+const initialProfile = {
+  name: '',
+  email: '',
+  phone: '',
+  birthDate: '',
+  loginId: '',
+  joinedAt: '',
+}
+
+const fieldLabels: Record<EditableField, string> = {
+  email: '이메일',
+  phone: '휴대폰 번호',
+}
+
+const fieldHelpers: Record<'email', string> = {
+  email: '변경할 이메일 주소를 입력해 주세요.',
+}
+
+const formatDateLabel = (value: string) => {
+  if (!value) {
+    return ''
+  }
+
+  return value.slice(0, 10).replace(/-/g, '.')
+}
+
+const getAlertMessage = (error: unknown) => {
+  if (axios.isAxiosError(error)) {
+    const serverMessage = (error.response?.data as { message?: string } | undefined)?.message?.trim()
+    return serverMessage || '처리 중 오류가 발생했습니다.'
+  }
+
+  if (error instanceof Error) {
+    const message = error.message.trim()
+    if (message) {
+      return message
+    }
+  }
+
+  return '처리 중 오류가 발생했습니다.'
+}
 
 export const MyProfilePage = () => {
+  const navigate = useNavigate()
+  const clearSession = useAuthStore((state) => state.clearSession)
+  const [profile, setProfile] = useState(initialProfile)
+  const [draftProfile, setDraftProfile] = useState(initialProfile)
+  const [activeEditor, setActiveEditor] = useState<EditableField | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [isSavingEmail, setIsSavingEmail] = useState(false)
+  const [isCheckingCurrentPassword, setIsCheckingCurrentPassword] = useState(false)
+  const [isUpdatingPassword, setIsUpdatingPassword] = useState(false)
+  const [isVerifying, setIsVerifying] = useState(false)
+  const [isWithdrawConfirmOpen, setIsWithdrawConfirmOpen] = useState(false)
+  const [isWithdrawCompleted, setIsWithdrawCompleted] = useState(false)
+  const [isWithdrawing, setIsWithdrawing] = useState(false)
+  const [errorMessage, setErrorMessage] = useState('')
+  const [successMessage, setSuccessMessage] = useState('')
+  const [currentPasswordCheck, setCurrentPasswordCheck] = useState<{
+    matched: boolean | null
+    message: string
+  }>({
+    matched: null,
+    message: '',
+  })
+  const [passwordForm, setPasswordForm] = useState({
+    currentPassword: '',
+    nextPassword: '',
+    nextPasswordConfirm: '',
+  })
+  const isNextPasswordFilled =
+    passwordForm.nextPassword.length > 0 && passwordForm.nextPasswordConfirm.length > 0
+  const isNextPasswordMatched =
+    isNextPasswordFilled && passwordForm.nextPassword === passwordForm.nextPasswordConfirm
+  const isNextPasswordMismatched =
+    isNextPasswordFilled && passwordForm.nextPassword !== passwordForm.nextPasswordConfirm
+  const isPasswordChangeDisabled =
+    isUpdatingPassword ||
+    isCheckingCurrentPassword ||
+    currentPasswordCheck.matched !== true ||
+    !isNextPasswordMatched
+  const withdrawCompleteImage = getS3AssetUrl('delete.png')
+
+  useEffect(() => {
+    const fetchProfile = async () => {
+      setIsLoading(true)
+      setErrorMessage('')
+
+      try {
+        const response = await getMyProfile()
+        const nextProfile = {
+          name: response.name,
+          email: response.email,
+          phone: response.phoneNumber,
+          birthDate: formatDateLabel(response.birthdate),
+          loginId: response.loginId,
+          joinedAt: formatDateLabel(response.joinedAt),
+        }
+
+        setProfile(nextProfile)
+        setDraftProfile(nextProfile)
+      } catch (error) {
+        setErrorMessage(getAlertMessage(error))
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    void fetchProfile()
+  }, [])
+
+  const handleBottomNavigation = (key: string) => {
+    const nextPath =
+      BOTTOM_NAVIGATION_ROUTE_BY_KEY[key as keyof typeof BOTTOM_NAVIGATION_ROUTE_BY_KEY]
+
+    if (nextPath) {
+      navigate(nextPath)
+    }
+  }
+
+  const handleEditorOpen = (field: EditableField) => {
+    if (isLoading) {
+      return
+    }
+
+    setDraftProfile(profile)
+    setActiveEditor(field)
+  }
+
+  const handleEditorCancel = () => {
+    setDraftProfile(profile)
+    setActiveEditor(null)
+  }
+
+  const handleProfileSave = async () => {
+    if (isSavingEmail) {
+      return
+    }
+
+    setIsSavingEmail(true)
+    setErrorMessage('')
+
+    try {
+      const response = await updateMyEmail(draftProfile.email)
+
+      setProfile((currentProfile) => ({
+        ...currentProfile,
+        email: response.email,
+      }))
+      setDraftProfile((currentProfile) => ({
+        ...currentProfile,
+        email: response.email,
+      }))
+      setActiveEditor(null)
+      setSuccessMessage(response.message)
+    } catch (error) {
+      setErrorMessage(getAlertMessage(error))
+    } finally {
+      setIsSavingEmail(false)
+    }
+  }
+
+  const handleStartPhoneVerification = async () => {
+    if (isVerifying) {
+      return
+    }
+
+    setIsVerifying(true)
+    setErrorMessage('')
+
+    try {
+      const impUid = await identityVerificationService.requestImpUid()
+      const response = await updateMyPhoneNumber(impUid)
+
+      setProfile((currentProfile) => ({
+        ...currentProfile,
+        phone: response.phoneNumber,
+      }))
+      setDraftProfile((currentProfile) => ({
+        ...currentProfile,
+        phone: response.phoneNumber,
+      }))
+      setActiveEditor(null)
+    } catch (error) {
+      setErrorMessage(getAlertMessage(error))
+    } finally {
+      setIsVerifying(false)
+    }
+  }
+
+  const runCurrentPasswordCheck = async (currentPassword: string) => {
+    const trimmedPassword = currentPassword.trim()
+
+    if (!trimmedPassword) {
+      setCurrentPasswordCheck({
+        matched: null,
+        message: '',
+      })
+      return null
+    }
+
+    setIsCheckingCurrentPassword(true)
+
+    try {
+      const response = await checkMyPassword(trimmedPassword)
+      setCurrentPasswordCheck({
+        matched: response.matched,
+        message: response.message,
+      })
+      return response.matched
+    } catch (error) {
+      setErrorMessage(getAlertMessage(error))
+      return null
+    } finally {
+      setIsCheckingCurrentPassword(false)
+    }
+  }
+
+  const handleCurrentPasswordBlur = async () => {
+    await runCurrentPasswordCheck(passwordForm.currentPassword)
+  }
+
+  const handlePasswordChange = async () => {
+    if (isUpdatingPassword || isCheckingCurrentPassword) {
+      return
+    }
+
+    if (!passwordForm.currentPassword.trim()) {
+      setErrorMessage('현재 비밀번호를 입력해주세요.')
+      return
+    }
+
+    if (!isNextPasswordMatched) {
+      setErrorMessage('새 비밀번호가 일치하지 않습니다.')
+      return
+    }
+
+    let isCurrentPasswordMatched = currentPasswordCheck.matched === true
+
+    if (!isCurrentPasswordMatched) {
+      isCurrentPasswordMatched =
+        (await runCurrentPasswordCheck(passwordForm.currentPassword)) === true
+    }
+
+    if (!isCurrentPasswordMatched) {
+      return
+    }
+
+    setIsUpdatingPassword(true)
+    setErrorMessage('')
+
+    try {
+      const response = await updateMyPassword(
+        passwordForm.currentPassword.trim(),
+        passwordForm.nextPassword,
+        passwordForm.nextPasswordConfirm,
+      )
+
+      setPasswordForm({
+        currentPassword: '',
+        nextPassword: '',
+        nextPasswordConfirm: '',
+      })
+      setCurrentPasswordCheck({
+        matched: null,
+        message: '',
+      })
+      setSuccessMessage(response.message)
+    } catch (error) {
+      setErrorMessage(getAlertMessage(error))
+    } finally {
+      setIsUpdatingPassword(false)
+    }
+  }
+
+  const handleWithdrawConfirmOpen = () => {
+    setIsWithdrawConfirmOpen(true)
+  }
+
+  const handleWithdrawConfirmClose = () => {
+    setIsWithdrawConfirmOpen(false)
+  }
+
+  const handleWithdrawComplete = async () => {
+    if (isWithdrawing) {
+      return
+    }
+
+    setIsWithdrawing(true)
+    setErrorMessage('')
+
+    try {
+      await withdrawMyAccount()
+      setIsWithdrawConfirmOpen(false)
+      setIsWithdrawCompleted(true)
+    } catch (error) {
+      setIsWithdrawConfirmOpen(false)
+      setErrorMessage(getAlertMessage(error))
+    } finally {
+      setIsWithdrawing(false)
+    }
+  }
+
+  const handleMoveToLogin = () => {
+    clearSession()
+    localStorage.removeItem('accessToken')
+    localStorage.removeItem('refreshToken')
+    navigate(ROUTE_PATHS.login, { replace: true })
+  }
+
+  const renderEditableRow = (field: EditableField, isLast: boolean) => {
+    const isEditing = activeEditor === field
+
+    return (
+      <div key={field} className={isLast ? '' : 'border-b border-gray-100'}>
+        <div className="flex items-center justify-between gap-4 px-5 py-4">
+          <div className="min-w-0">
+            <p className="text-xs font-medium text-font-sub">{fieldLabels[field]}</p>
+            <p className="mt-1 truncate text-sm font-medium text-font-main">{profile[field]}</p>
+          </div>
+
+          <Button
+            type="button"
+            variant="gray"
+            size="sm"
+            className="shrink-0 !h-8 !rounded-full !px-3 !text-xs !font-medium"
+            onClick={() => handleEditorOpen(field)}
+          >
+            수정
+          </Button>
+        </div>
+
+        {isEditing ? (
+          <div className="border-t border-gray-100 bg-gray-50 px-5 py-4">
+            {field === 'email' ? (
+              <>
+                <Input
+                  label={fieldLabels[field]}
+                  value={draftProfile[field]}
+                  onChange={(event) =>
+                    setDraftProfile((currentDraft) => ({
+                      ...currentDraft,
+                      [field]: event.target.value,
+                    }))
+                  }
+                  helperText={fieldHelpers[field]}
+                />
+
+                <div className="mt-4 flex gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="flex-1"
+                    onClick={handleEditorCancel}
+                  >
+                    취소
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    className="flex-1"
+                    disabled={isSavingEmail}
+                    onClick={() => void handleProfileSave()}
+                  >
+                    저장
+                  </Button>
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="rounded-control border border-primary-100 bg-white px-4 py-4">
+                  <p className="text-sm leading-6 text-font-sub text-center">
+                    휴대폰 번호 변경 시 본인인증이 필요합니다.
+                  </p>
+                </div>
+
+                <div className="mt-4 flex gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="flex-1"
+                    onClick={handleEditorCancel}
+                  >
+                    취소
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    className="flex-1"
+                    disabled={isVerifying}
+                    onClick={handleStartPhoneVerification}
+                  >
+                    {isVerifying ? '인증 확인 중...' : '본인인증 시작'}
+                  </Button>
+                </div>
+              </>
+            )}
+          </div>
+        ) : null}
+      </div>
+    )
+  }
+
+  if (isWithdrawCompleted) {
+    return (
+      <MainLayout
+        header={<ShopHeader title="회원탈퇴 완료" onBack={handleMoveToLogin} />}
+        className="bg-bg-light"
+      >
+        <div className="flex min-h-[calc(100dvh-var(--header-h)-40px)] flex-col pb-32">
+          <div className="flex flex-1 flex-col items-center justify-center text-center">
+            <div className="flex flex-col gap-1">
+              <img
+                src={withdrawCompleteImage}
+                alt="회원탈퇴 완료"
+                className="mx-auto h-[230px] w-[230px] object-contain"
+              />
+              <p className="text-[22px] font-semibold text-font-main -mt-8">회원탈퇴가 완료되었습니다.</p>
+              <p className="text-sm leading-6 text-font-sub">이용해주셔서 감사합니다.</p>
+            </div>
+          </div>
+
+          <div className="fixed bottom-0 left-1/2 z-10 w-full max-w-[600px] -translate-x-1/2 bg-bg-light px-5 pb-[calc(env(safe-area-inset-bottom)+16px)] pt-4">
+            <Button type="button" fullWidth onClick={handleMoveToLogin}>
+              메인화면으로
+            </Button>
+          </div>
+        </div>
+      </MainLayout>
+    )
+  }
+
   return (
-    <PageScaffold
-      title="프로필 및 계정 관리"
-      description="닉네임, 연락처 등 회원 기본 정보와 계정 정보를 관리하는 화면입니다."
-    />
+    <MainLayout
+      header={<ShopHeader title="프로필 및 계정 관리" onBack={() => navigate(ROUTE_PATHS.my)} />}
+      nav={
+        <BottomNavigation
+          items={BOTTOM_NAVIGATION_ITEMS}
+          value="my"
+          onChange={handleBottomNavigation}
+        />
+      }
+      className="bg-bg-light"
+    >
+      <div className="mt-5 flex flex-col gap-5 pb-2">
+        <Card className="!gap-0 !border-0 !px-5 !py-5 shadow-sm">
+          <div className="flex items-center gap-4">
+            <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-primary-50 text-[22px] font-semibold text-primary-500">
+              {profile.name.charAt(0)}
+            </div>
+
+            <div className="min-w-0 flex-1 self-stretch flex flex-col justify-center">
+              <div className="flex items-center gap-2">
+                <p className="text-[20px] font-semibold leading-none text-font-main">
+                  {isLoading ? '불러오는 중...' : profile.name}
+                </p>
+                <Badge tone="primary" variant="soft" className="!px-[8px] !py-[4px]">
+                  본인인증 완료
+                </Badge>
+              </div>
+
+              <div className="mt-2 flex flex-col gap-1">
+                <p className="text-sm text-font-sub">{profile.email || '-'}</p>
+                <p className="text-sm text-font-sub">{profile.phone || '-'}</p>
+              </div>
+            </div>
+          </div>
+        </Card>
+
+        <section className="flex flex-col gap-3">
+          <SectionHeader title="기본 정보" className="px-1" />
+
+          <Card className="!gap-0 !p-0">
+            {renderEditableRow('email', false)}
+            {renderEditableRow('phone', true)}
+          </Card>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <SectionHeader title="계정 정보" className="px-1" />
+
+          <Card className="!gap-5">
+            <InfoRow label="아이디" value={profile.loginId || '-'} />
+            <InfoRow label="생년월일" value={profile.birthDate || '-'} />
+            <InfoRow label="가입일" value={profile.joinedAt || '-'} />
+          </Card>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <SectionHeader title="비밀번호 변경" className="px-1" />
+
+          <Card className="!gap-0">
+            <div className="flex flex-col gap-5">
+              <Input
+                label="현재 비밀번호"
+                type="password"
+                placeholder="현재 비밀번호를 입력해 주세요."
+                helperText={
+                  isCheckingCurrentPassword
+                    ? '현재 비밀번호 확인 중...'
+                    : currentPasswordCheck.matched
+                      ? currentPasswordCheck.message
+                      : undefined
+                }
+                errorText={
+                  currentPasswordCheck.matched === false
+                    ? currentPasswordCheck.message
+                    : undefined
+                }
+                isVerified={currentPasswordCheck.matched === true}
+                value={passwordForm.currentPassword}
+                onBlur={() => void handleCurrentPasswordBlur()}
+                onChange={(event) => {
+                  setPasswordForm((currentForm) => ({
+                    ...currentForm,
+                    currentPassword: event.target.value,
+                  }))
+                  setCurrentPasswordCheck({
+                    matched: null,
+                    message: '',
+                  })
+                }}
+              />
+              <Input
+                label="새 비밀번호"
+                type="password"
+                placeholder="새 비밀번호를 입력해 주세요."
+                value={passwordForm.nextPassword}
+                onChange={(event) =>
+                  setPasswordForm((currentForm) => ({
+                    ...currentForm,
+                    nextPassword: event.target.value,
+                  }))
+                }
+              />
+              <Input
+                label="새 비밀번호 확인"
+                type="password"
+                placeholder="새 비밀번호를 다시 입력해 주세요."
+                helperText={isNextPasswordMatched ? '새 비밀번호가 일치합니다.' : undefined}
+                errorText={
+                  isNextPasswordMismatched ? '새 비밀번호가 일치하지 않습니다.' : undefined
+                }
+                isVerified={isNextPasswordMatched}
+                value={passwordForm.nextPasswordConfirm}
+                onChange={(event) =>
+                  setPasswordForm((currentForm) => ({
+                    ...currentForm,
+                    nextPasswordConfirm: event.target.value,
+                  }))
+                }
+              />
+            </div>
+
+            <Button
+              type="button"
+              fullWidth
+              className="mt-5"
+              disabled={isPasswordChangeDisabled}
+              onClick={() => void handlePasswordChange()}
+            >
+              {isUpdatingPassword ? '변경 중...' : '비밀번호 변경'}
+            </Button>
+          </Card>
+        </section>
+
+        <button
+          type="button"
+          className="mt-1 self-center text-sm font-medium text-red-500"
+          onClick={handleWithdrawConfirmOpen}
+        >
+          회원탈퇴
+        </button>
+      </div>
+      {isWithdrawConfirmOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/35 px-6">
+          <div className="w-full max-w-sm rounded-2xl bg-white p-6 shadow-lg">
+            <p className="text-center text-sm font-medium text-font-main">
+              회원탈퇴 하시겠습니까?
+            </p>
+            <div className="mt-5 flex gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                fullWidth
+                onClick={handleWithdrawConfirmClose}
+              >
+                취소
+              </Button>
+              <Button
+                type="button"
+                variant="primary"
+                fullWidth
+                disabled={isWithdrawing}
+                onClick={() => void handleWithdrawComplete()}
+              >
+                {isWithdrawing ? '처리 중...' : '확인'}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+      {errorMessage && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/35 px-6">
+          <div className="w-full max-w-sm rounded-2xl bg-white p-6 shadow-lg">
+            <p className="text-center text-sm font-medium text-font-main">{errorMessage}</p>
+            <Button
+              type="button"
+              variant="primary"
+              fullWidth
+              className="mt-5"
+              onClick={() => setErrorMessage('')}
+            >
+              확인
+            </Button>
+          </div>
+        </div>
+      )}
+      {successMessage && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/35 px-6">
+          <div className="w-full max-w-sm rounded-2xl bg-white p-6 shadow-lg">
+            <p className="text-center text-sm font-medium text-font-main">{successMessage}</p>
+            <Button
+              type="button"
+              variant="primary"
+              fullWidth
+              className="mt-5"
+              onClick={() => setSuccessMessage('')}
+            >
+              확인
+            </Button>
+          </div>
+        </div>
+      )}
+    </MainLayout>
   )
 }

--- a/src/services/identityVerificationService.ts
+++ b/src/services/identityVerificationService.ts
@@ -5,6 +5,7 @@ import type { PortOneCertificationResponse } from '../types/portone'
 type VerifyIdentityResponse = {
   verified: boolean
   verificationToken?: string
+  preservedLoginId?: string
 }
 
 async function requestImpCertification(): Promise<string> {
@@ -55,6 +56,7 @@ async function requestImpCertification(): Promise<string> {
 }
 
 export const identityVerificationService = {
+  requestImpUid: requestImpCertification,
   verify: async (): Promise<VerifyIdentityResponse> => {
     const impUid = await requestImpCertification()
     const response = await apiClient.post<VerifyIdentityResponse>('/v1/auth/verify-identity', {

--- a/src/services/userProfileService.ts
+++ b/src/services/userProfileService.ts
@@ -1,0 +1,62 @@
+import { apiClient } from './apiClient'
+import type {
+  CheckMyPasswordResponse,
+  UpdateMyEmailResponse,
+  UpdateMyPasswordResponse,
+  UpdateMyPhoneNumberResponse,
+  WithdrawMyAccountResponse,
+  UserProfile,
+} from '../types/userProfile'
+
+export const getMyProfile = async (): Promise<UserProfile> => {
+  const response = await apiClient.get<UserProfile>('/my/profile')
+  return response.data
+}
+
+export const updateMyPhoneNumber = async (
+  impUid: string,
+): Promise<UpdateMyPhoneNumberResponse> => {
+  const response = await apiClient.patch<UpdateMyPhoneNumberResponse>('/my/profile/phone', {
+    impUid,
+  })
+
+  return response.data
+}
+
+export const updateMyEmail = async (email: string): Promise<UpdateMyEmailResponse> => {
+  const response = await apiClient.patch<UpdateMyEmailResponse>('/my/profile/email', {
+    email,
+  })
+
+  return response.data
+}
+
+export const checkMyPassword = async (
+  currentPassword: string,
+): Promise<CheckMyPasswordResponse> => {
+  const response = await apiClient.post<CheckMyPasswordResponse>('/my/profile/password/check', {
+    currentPassword,
+  })
+
+  return response.data
+}
+
+export const updateMyPassword = async (
+  currentPassword: string,
+  newPassword: string,
+  newPasswordConfirm: string,
+): Promise<UpdateMyPasswordResponse> => {
+  const response = await apiClient.patch<UpdateMyPasswordResponse>('/my/profile/password', {
+    currentPassword,
+    newPassword,
+    newPasswordConfirm,
+  })
+
+  return response.data
+}
+
+export const withdrawMyAccount = async (): Promise<WithdrawMyAccountResponse> => {
+  const response = await apiClient.patch<WithdrawMyAccountResponse>('/my/profile/withdraw')
+
+  return response.data
+}

--- a/src/types/userProfile.ts
+++ b/src/types/userProfile.ts
@@ -1,0 +1,31 @@
+export interface UserProfile {
+  loginId: string
+  name: string
+  email: string
+  phoneNumber: string
+  birthdate: string
+  joinedAt: string
+}
+
+export interface UpdateMyPhoneNumberResponse {
+  phoneNumber: string
+  message: string
+}
+
+export interface UpdateMyEmailResponse {
+  email: string
+  message: string
+}
+
+export interface CheckMyPasswordResponse {
+  matched: boolean
+  message: string
+}
+
+export interface UpdateMyPasswordResponse {
+  message: string
+}
+
+export interface WithdrawMyAccountResponse {
+  message: string
+}


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이슈 번호를 적어주세요. 머지 시 자동으로 이슈가 닫힙니다. -->
Closes #49

## 📌 작업 내용
<!-- 어떤 작업을 했는지 간단히 설명 -->
- 마이페이지 프로필 및 계정 관리 화면을 구현하고, 프로필 조회/수정 흐름을 프론트에 연결
- 탈퇴 계정 재가입 흐름에 맞춰 회원가입 화면과 완료 화면을 보완

## 🛠 변경 사항
<!-- 주요 변경 파일이나 로직을 설명 -->
- MyProfilePage, userProfileService, userProfile 타입을 추가해 프로필 조회, 이메일/휴대폰 번호/비밀번호 변경, 회원탈퇴 UI를 구현
- MyPage에서 마이페이지 메뉴 구조를 정리하고 활동 메뉴 구성을 조정
- SignupAgreementPage, SignupPage, identityVerificationService를 수정해 탈퇴 계정 재가입 시 기존 아이디를 유지하는 흐름을 연결
- SignupCompletePage를 메인 레이아웃 기준으로 정리하고 완료 화면 디자인을 수정

## ✅ 테스트 결과
<!-- 테스트를 어떻게 했는지 (로컬 실행, API 테스트 등) -->
- [x] 로컬에서 정상 동작 확인
- [x] API 테스트 완료 (해당되면)
- [x] 빌드 에러 없음

## 📸 스크린샷
<!-- UI 변경이 있으면 스크린샷 첨부 -->

## 💡 리뷰어에게
<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분 -->
