### PR TITLE
[FEAT] 56 봉사활동 목록상세 조회 페이지 및 신청 완료 페이지 구현

### DIFF
--- a/src/components/common/Badge.tsx
+++ b/src/components/common/Badge.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'react'
 
 /**
  * 상태, 카테고리, 포인트 표시용 배지.
@@ -7,9 +7,9 @@ import React from 'react';
  * <Badge tone="success" variant="soft">+50P</Badge>
  */
 interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
-  children: React.ReactNode;
-  tone?: 'primary' | 'neutral' | 'success' | 'danger';
-  variant?: 'soft' | 'outline' | 'solid';
+  children: React.ReactNode
+  tone?: 'primary' | 'neutral' | 'success' | 'danger'
+  variant?: 'soft' | 'outline' | 'solid'
 }
 
 const Badge: React.FC<BadgeProps> = ({
@@ -21,9 +21,9 @@ const Badge: React.FC<BadgeProps> = ({
 }) => {
   const toneStyles = {
     primary: {
-      soft: 'bg-primary-50 text-primary-500',
+      soft: 'bg-primary-50 text-primary-400',
       outline: 'border border-primary-200 bg-white text-primary-500',
-      solid: 'bg-primary-500 text-white',
+      solid: 'bg-primary-400 text-white',
     },
     neutral: {
       soft: 'bg-gray-100 text-font-sub',
@@ -40,10 +40,10 @@ const Badge: React.FC<BadgeProps> = ({
       outline: 'border border-[#FECACA] bg-white text-error',
       solid: 'bg-error text-white',
     },
-  };
+  }
 
   return (
-      <span
+    <span
       className={`
         inline-flex items-center justify-center rounded-badge px-2 py-1
         text-xs font-medium leading-none
@@ -54,7 +54,7 @@ const Badge: React.FC<BadgeProps> = ({
     >
       {children}
     </span>
-  );
-};
+  )
+}
 
-export default Badge;
+export default Badge

--- a/src/components/common/BottomActionBar.tsx
+++ b/src/components/common/BottomActionBar.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Button from './Button';
 
 interface BottomActionBarProps {
-    leftText: string;
+    leftText: React.ReactNode;
     buttonLabel: string;
     onButtonClick?: () => void;
     className?: string;

--- a/src/components/common/BottomActionBar.tsx
+++ b/src/components/common/BottomActionBar.tsx
@@ -6,6 +6,8 @@ interface BottomActionBarProps {
     buttonLabel: string;
     onButtonClick?: () => void;
     className?: string;
+    buttonVariant?: 'primary' | 'outline' | 'sub' | 'gray';
+    buttonDisabled?: boolean;
 }
 
 const BottomActionBar: React.FC<BottomActionBarProps> = ({
@@ -13,6 +15,8 @@ const BottomActionBar: React.FC<BottomActionBarProps> = ({
     buttonLabel,
     onButtonClick,
     className = '',
+    buttonVariant = 'primary',
+    buttonDisabled = false,
 }) => {
     return (
         <div
@@ -28,7 +32,12 @@ const BottomActionBar: React.FC<BottomActionBarProps> = ({
                 </p>
 
                 <div className="min-w-0 flex-1">
-                    <Button fullWidth onClick={onButtonClick}>
+                    <Button
+                        fullWidth
+                        variant={buttonVariant}
+                        disabled={buttonDisabled}
+                        onClick={onButtonClick}
+                    >
                         {buttonLabel}
                     </Button>
                 </div>

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-
+import React from 'react'
 
 //  공통 버튼 (Button) 컴포넌트
 
@@ -9,65 +8,61 @@ import React from 'react';
 //  @param {boolean} fullWidth - 가로 길이를 100%로 채울지 여부 (기본값: false)
 //  @param {string} className - 추가 커스텀 스타일이 필요할 때 사용
 
-
-
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-    children: React.ReactNode;
-    variant?: 'primary' | 'outline' | 'sub' | 'gray';
-    size?: 'sm' | 'md' | 'lg';
-    fullWidth?: boolean;
+  children: React.ReactNode
+  variant?: 'primary' | 'outline' | 'sub' | 'gray'
+  size?: 'sm' | 'md' | 'lg'
+  fullWidth?: boolean
 }
 
 const Button: React.FC<ButtonProps> = ({
-    children,
-    variant = 'primary',
-    size = 'md',
-    fullWidth = false,
-    className = '',
-    type = 'button',
-    ...props
+  children,
+  variant = 'primary',
+  size = 'md',
+  fullWidth = false,
+  className = '',
+  type = 'button',
+  ...props
 }) => {
-    // 1. 상태별 컬러 정의 (Fallback으로 절대 색상을 함께 적용하여 항상 명확히 보이도록)
-    const variantStyles = {
-        // 메인 버튼: primary
-        primary: '!bg-primary-500 !bg-[#0046FF] !text-white !border-0 disabled:!bg-gray-200 disabled:!text-gray-400',
+  // 1. 상태별 컬러 정의 (Fallback으로 절대 색상을 함께 적용하여 항상 명확히 보이도록)
+  const variantStyles = {
+    // 메인 버튼: primary
+    primary:
+      '!bg-primary-400 !bg-[#0046FF] !text-white !border-0 disabled:!bg-gray-200 disabled:!text-gray-400',
 
-        // 서브 버튼: subtle primary
-        sub: '!bg-primary-100 !bg-[#CCDAFF] !text-primary-400 disabled:!bg-gray-200 disabled:!text-gray-400',
+    // 서브 버튼: subtle primary
+    sub: '!bg-primary-100 !bg-[#CCDAFF] !text-primary-400 disabled:!bg-gray-200 disabled:!text-gray-400',
 
-        // 아웃라인 버튼
-        outline: '!bg-white !border !border-primary-500 !text-primary-500 disabled:!border-gray-200 disabled:!text-gray-400',
+    // 아웃라인 버튼
+    outline:
+      '!bg-white !border !border-primary-500 !text-primary-500 disabled:!border-gray-200 disabled:!text-gray-400',
 
-        // 회색 버튼
-        gray: '!bg-gray-100 !text-font-main disabled:!bg-gray-200 disabled:!text-gray-400',
-    };
+    // 회색 버튼
+    gray: '!bg-gray-100 !text-font-main disabled:!bg-gray-200 disabled:!text-gray-400',
+  }
 
-    // 2. 크기 및 폰트 규격 정의 (16px + Semibold 고정)
-    const sizeStyles = {
-        sm: 'h-[36px] px-3 text-xs font-medium',
-        // 기본 사이즈 (md): 폰트 16px (text-base) + 세미볼드 (font-semibold)
-        md: 'h-[48px] px-4 text-base font-semibold',
-        lg: 'h-[52px] px-6 text-lg font-semibold',
-    };
+  // 2. 크기 및 폰트 규격 정의 (16px + Semibold 고정)
+  const sizeStyles = {
+    sm: 'h-[36px] px-3 text-xs font-medium',
+    // 기본 사이즈 (md): 폰트 16px (text-base) + 세미볼드 (font-semibold)
+    md: 'h-[48px] px-4 text-base font-semibold',
+    lg: 'h-[52px] px-6 text-lg font-semibold',
+  }
 
-    const buttonClassName = [
-        'flex items-center justify-center rounded-control transition-all duration-200',
-        'active:scale-[0.98] cursor-pointer disabled:cursor-not-allowed',
-        variantStyles[variant],
-        sizeStyles[size],
-        fullWidth ? 'w-full' : 'w-fit',
-        className,
-    ].join(' ');
+  const buttonClassName = [
+    'flex items-center justify-center rounded-control transition-all duration-200',
+    'active:scale-[0.98] cursor-pointer disabled:cursor-not-allowed',
+    variantStyles[variant],
+    sizeStyles[size],
+    fullWidth ? 'w-full' : 'w-fit',
+    className,
+  ].join(' ')
 
-    return (
-        <button
-            type={type}
-            className={buttonClassName}
-            {...props}
-        >
-            {children}
-        </button>
-    );
-};
+  return (
+    <button type={type} className={buttonClassName} {...props}>
+      {children}
+    </button>
+  )
+}
 
-export default Button;
+export default Button

--- a/src/constants/routePaths.ts
+++ b/src/constants/routePaths.ts
@@ -19,6 +19,7 @@ export const ROUTE_PATHS = {
   activitySocial: '/activities/social',
   activitySocialDonation: '/esg/social/donation',
   activitySocialStore: '/esg/social/store',
+  activitySocialVolunteer: '/esg/social/volunteer',
   activitySocialProductDetail: '/esg/social/products/:productId',
   activitySocialProductPayment: '/esg/social/products/:productId/payment',
   activitySocialProductPaymentCallback:

--- a/src/constants/routePaths.ts
+++ b/src/constants/routePaths.ts
@@ -20,6 +20,7 @@ export const ROUTE_PATHS = {
   activitySocialDonation: '/esg/social/donation',
   activitySocialStore: '/esg/social/store',
   activitySocialVolunteer: '/esg/social/volunteer',
+  activitySocialVolunteerDetail: '/esg/social/volunteers/:volunteerId',
   activitySocialProductDetail: '/esg/social/products/:productId',
   activitySocialProductPayment: '/esg/social/products/:productId/payment',
   activitySocialProductPaymentCallback:
@@ -62,6 +63,9 @@ export const getDonationPaymentCompletePath = (donationId: number | string) =>
 
 export const getValueStoreProductDetailPath = (productId: number | string) =>
   `/esg/social/products/${productId}`
+
+export const getVolunteerDetailPath = (volunteerId: number | string) =>
+  `/esg/social/volunteers/${volunteerId}`
 
 export const getValueStoreProductPaymentPath = (productId: number | string) =>
   `/esg/social/products/${productId}/payment`

--- a/src/constants/routePaths.ts
+++ b/src/constants/routePaths.ts
@@ -21,6 +21,7 @@ export const ROUTE_PATHS = {
   activitySocialStore: '/esg/social/store',
   activitySocialVolunteer: '/esg/social/volunteer',
   activitySocialVolunteerDetail: '/esg/social/volunteers/:volunteerId',
+  activitySocialVolunteerComplete: '/esg/social/volunteers/:volunteerId/complete',
   activitySocialProductDetail: '/esg/social/products/:productId',
   activitySocialProductPayment: '/esg/social/products/:productId/payment',
   activitySocialProductPaymentCallback:
@@ -66,6 +67,9 @@ export const getValueStoreProductDetailPath = (productId: number | string) =>
 
 export const getVolunteerDetailPath = (volunteerId: number | string) =>
   `/esg/social/volunteers/${volunteerId}`
+
+export const getVolunteerCompletePath = (volunteerId: number | string) =>
+  `/esg/social/volunteers/${volunteerId}/complete`
 
 export const getValueStoreProductPaymentPath = (productId: number | string) =>
   `/esg/social/products/${productId}/payment`

--- a/src/pages/esg/social/DonationPage.tsx
+++ b/src/pages/esg/social/DonationPage.tsx
@@ -100,7 +100,7 @@ export function DonationPage() {
             <div className="h-28 animate-pulse rounded-control bg-primary-300" />
 
             <div className="space-y-4">
-              <div className="flex items-center justify-between px-[6px]">
+              <div className="flex items-center justify-between">
                 <div className="h-5 w-28 animate-pulse rounded-full bg-gray-300" />
                 <div className="h-4 w-10 animate-pulse rounded-full bg-primary-100" />
               </div>
@@ -158,7 +158,7 @@ export function DonationPage() {
           />
 
           <section className="space-y-4">
-            <div className="flex items-center justify-between px-[6px]">
+            <div className="flex items-center justify-between">
               <h2 className="text-lg leading-[120%] font-semibold text-font-main">
                 진행중인 캠페인
               </h2>

--- a/src/pages/esg/social/ValueStorePage.tsx
+++ b/src/pages/esg/social/ValueStorePage.tsx
@@ -88,7 +88,7 @@ export function ValueStorePage() {
       {isLoading ? (
         <div className="flex flex-col gap-6">
           <section className="space-y-4 pt-2">
-            <div className="flex items-center justify-between px-[6px]">
+            <div className="flex items-center justify-between">
               <div className="h-5 w-28 animate-pulse rounded-full bg-gray-300" />
               <div className="h-4 w-20 animate-pulse rounded-full bg-primary-100" />
             </div>
@@ -132,7 +132,7 @@ export function ValueStorePage() {
       {!isLoading && !error && productData ? (
         <div className="flex flex-col gap-6 pt-2">
           <section className="space-y-4">
-            <div className="flex items-center justify-between px-[6px]">
+            <div className="flex items-center justify-between">
               <h2 className="text-lg leading-[120%] font-semibold text-gray-700">
                 판매중인 상품
               </h2>

--- a/src/pages/esg/social/ValueStorePage.tsx
+++ b/src/pages/esg/social/ValueStorePage.tsx
@@ -130,7 +130,7 @@ export function ValueStorePage() {
       ) : null}
 
       {!isLoading && !error && productData ? (
-        <div className="flex flex-col gap-6 pt-2">
+        <div className="flex flex-col gap-6">
           <section className="space-y-4">
             <div className="flex items-center justify-between">
               <h2 className="text-lg leading-[120%] font-semibold text-gray-700">

--- a/src/pages/esg/social/VolunteerCompletePage.tsx
+++ b/src/pages/esg/social/VolunteerCompletePage.tsx
@@ -1,0 +1,129 @@
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
+import { Button, IconButton } from '../../../components/common'
+import { Icons } from '../../../components/common'
+import Header from '../../../components/layout/Header'
+import MainLayout from '../../../components/layout/MainLayout'
+import {
+  getVolunteerDetailPath,
+  ROUTE_PATHS,
+} from '../../../constants/routePaths'
+import type { VolunteerApplicationResponse } from '../../../types/volunteer'
+
+interface VolunteerCompleteLocationState {
+  application?: VolunteerApplicationResponse
+}
+
+const formatVolunteerDate = (activityDate: string) => {
+  const date = new Date(activityDate)
+
+  if (Number.isNaN(date.getTime())) {
+    return activityDate
+  }
+
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+
+  return `${year}.${month}.${day}`
+}
+
+export function VolunteerCompletePage() {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const { volunteerId } = useParams()
+  const state = location.state as VolunteerCompleteLocationState | undefined
+  const application = state?.application
+
+  return (
+    <MainLayout
+      header={
+        <Header
+          left={
+            <IconButton
+              label="뒤로가기"
+              icon={<Icons.Back className="text-font-main" />}
+              onClick={() => navigate(ROUTE_PATHS.activitySocialVolunteer)}
+            />
+          }
+          title="봉사"
+        />
+      }
+      className="bg-gray-50"
+    >
+      <section className="mx-[-16px] min-h-[calc(100vh-var(--header-h)-48px)] bg-gray-50 px-4 pt-6 pb-8">
+        {application ? (
+          <div className="space-y-4">
+            <section className="rounded-control bg-white px-6 py-7 shadow-[0_2px_8px_rgba(0,0,0,0.05)]">
+              <div className="flex flex-col gap-2">
+                <p className="text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
+                  봉사 신청이 완료되었습니다.
+                </p>
+                <h2 className="text-[20px] leading-[140%] font-bold tracking-[-0.02em] text-font-main">
+                  {application.name}
+                </h2>
+              </div>
+            </section>
+
+            <section className="rounded-control bg-white px-6 py-6 shadow-[0_2px_8px_rgba(0,0,0,0.05)]">
+              <div className="space-y-5">
+                <div className="flex items-start justify-between gap-5">
+                  <p className="shrink-0 text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
+                    봉사명
+                  </p>
+                  <p className="text-right text-sm leading-6 font-normal tracking-[-0.02em] text-gray-600">
+                    {application.name}
+                  </p>
+                </div>
+
+                <div className="flex items-start justify-between gap-5">
+                  <p className="shrink-0 text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
+                    봉사 장소
+                  </p>
+                  <p className="text-right text-sm leading-6 font-normal tracking-[-0.02em] text-gray-600">
+                    {application.location}
+                  </p>
+                </div>
+
+                <div className="flex items-start justify-between gap-5">
+                  <p className="shrink-0 text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
+                    봉사 날짜
+                  </p>
+                  <p className="text-right text-sm leading-6 font-normal tracking-[-0.02em] text-gray-600">
+                    {formatVolunteerDate(application.activityDate)}
+                  </p>
+                </div>
+              </div>
+            </section>
+
+            <Button
+              fullWidth
+              onClick={() => navigate(ROUTE_PATHS.activitySocialVolunteer)}
+            >
+              목록으로 돌아가기
+            </Button>
+          </div>
+        ) : (
+          <section className="rounded-card border border-gray-100 bg-white px-5 py-6 text-center shadow-card">
+            <h2 className="text-lg font-semibold text-font-main">
+              신청 정보를 확인할 수 없어요
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-font-sub">
+              다시 상세 페이지에서 신청을 진행해주세요.
+            </p>
+            <Button
+              className="mt-5"
+              fullWidth
+              onClick={() =>
+                volunteerId
+                  ? navigate(getVolunteerDetailPath(volunteerId))
+                  : navigate(ROUTE_PATHS.activitySocialVolunteer)
+              }
+            >
+              상세 페이지로 돌아가기
+            </Button>
+          </section>
+        )}
+      </section>
+    </MainLayout>
+  )
+}

--- a/src/pages/esg/social/VolunteerCompletePage.tsx
+++ b/src/pages/esg/social/VolunteerCompletePage.tsx
@@ -1,8 +1,7 @@
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
-import { Button, IconButton } from '../../../components/common'
-import { Icons } from '../../../components/common'
-import Header from '../../../components/layout/Header'
+import { Button } from '../../../components/common'
 import MainLayout from '../../../components/layout/MainLayout'
+import completeCharacterImage from '../../../assets/good.png'
 import {
   getVolunteerDetailPath,
   ROUTE_PATHS,
@@ -35,93 +34,105 @@ export function VolunteerCompletePage() {
   const application = state?.application
 
   return (
-    <MainLayout
-      header={
-        <Header
-          left={
-            <IconButton
-              label="뒤로가기"
-              icon={<Icons.Back className="text-font-main" />}
-              onClick={() => navigate(ROUTE_PATHS.activitySocialVolunteer)}
-            />
-          }
-          title="봉사"
-        />
-      }
-      className="bg-gray-50"
-    >
-      <section className="mx-[-16px] min-h-[calc(100vh-var(--header-h)-48px)] bg-gray-50 px-4 pt-6 pb-8">
+    <MainLayout className="bg-gray-50">
+      <section className="mx-[-16px] my-[-24px] bg-gray-50 px-[31px] pt-[88px] pb-6">
         {application ? (
-          <div className="space-y-4">
-            <section className="rounded-control bg-white px-6 py-7 shadow-[0_2px_8px_rgba(0,0,0,0.05)]">
-              <div className="flex flex-col gap-2">
-                <p className="text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
-                  봉사 신청이 완료되었습니다.
+          <div className="mx-auto flex max-w-[340px] flex-col items-center text-center">
+            <div className="flex flex-col items-center text-center">
+              <img
+                src={completeCharacterImage}
+                alt=""
+                className="h-[104px] w-[95px] object-cover"
+              />
+              <div className="mt-[11px] flex w-full flex-col items-center gap-2">
+                <h1 className="text-[20px] leading-[30px] font-bold tracking-[-0.02em] text-font-main">
+                  신청이 완료되었습니다!
+                </h1>
+                <p className="text-center text-[12px] leading-6 font-medium tracking-[-0.02em] text-font-sub">
+                  봉사활동에 함께해 주셔서 감사합니다.
                 </p>
-                <h2 className="text-[20px] leading-[140%] font-bold tracking-[-0.02em] text-font-main">
-                  {application.name}
-                </h2>
               </div>
-            </section>
+            </div>
 
-            <section className="rounded-control bg-white px-6 py-6 shadow-[0_2px_8px_rgba(0,0,0,0.05)]">
-              <div className="space-y-5">
-                <div className="flex items-start justify-between gap-5">
-                  <p className="shrink-0 text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
-                    봉사명
-                  </p>
-                  <p className="text-right text-sm leading-6 font-normal tracking-[-0.02em] text-gray-600">
-                    {application.name}
-                  </p>
+            <div className="mt-[23px] flex w-full flex-col">
+              <div className="rounded-card bg-white px-[15px] pt-[19px] pb-[18px] text-left shadow-card">
+                <div className="text-left text-[12px] leading-6 font-bold tracking-[-0.02em] text-font-sub">
+                  신청내역 상세
                 </div>
 
-                <div className="flex items-start justify-between gap-5">
-                  <p className="shrink-0 text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
-                    봉사 장소
-                  </p>
-                  <p className="text-right text-sm leading-6 font-normal tracking-[-0.02em] text-gray-600">
-                    {application.location}
-                  </p>
-                </div>
+                <div className="mt-4 flex flex-col gap-[14px]">
+                  <div className="flex items-center justify-between gap-4">
+                    <span className="text-[12px] leading-6 font-medium tracking-[-0.02em] text-font-sub">
+                      봉사명
+                    </span>
+                    <span className="text-right text-[16px] leading-6 font-semibold tracking-[-0.02em] text-font-sub">
+                      {application.name}
+                    </span>
+                  </div>
 
-                <div className="flex items-start justify-between gap-5">
-                  <p className="shrink-0 text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
-                    봉사 날짜
-                  </p>
-                  <p className="text-right text-sm leading-6 font-normal tracking-[-0.02em] text-gray-600">
-                    {formatVolunteerDate(application.activityDate)}
-                  </p>
+                  <div className="flex items-center justify-between gap-4">
+                    <span className="text-[12px] leading-6 font-medium tracking-[-0.02em] text-font-sub">
+                      봉사 장소
+                    </span>
+                    <span className="text-right text-[16px] leading-6 font-semibold tracking-[-0.02em] text-font-sub">
+                      {application.location}
+                    </span>
+                  </div>
+
+                  <div className="flex items-center justify-between gap-4">
+                    <span className="text-[12px] leading-6 font-medium tracking-[-0.02em] text-font-sub">
+                      봉사 날짜
+                    </span>
+                    <span className="text-right text-[16px] leading-6 font-semibold tracking-[-0.02em] text-font-sub">
+                      {formatVolunteerDate(application.activityDate)}
+                    </span>
+                  </div>
                 </div>
               </div>
-            </section>
 
-            <Button
-              fullWidth
-              onClick={() => navigate(ROUTE_PATHS.activitySocialVolunteer)}
-            >
-              목록으로 돌아가기
-            </Button>
+              <div className="mt-5 w-full">
+                <Button
+                  fullWidth
+                  size="md"
+                  onClick={() => navigate(ROUTE_PATHS.home, { replace: true })}
+                >
+                  메인으로 가기
+                </Button>
+              </div>
+            </div>
           </div>
         ) : (
-          <section className="rounded-card border border-gray-100 bg-white px-5 py-6 text-center shadow-card">
-            <h2 className="text-lg font-semibold text-font-main">
-              신청 정보를 확인할 수 없어요
-            </h2>
-            <p className="mt-2 text-sm leading-6 text-font-sub">
-              다시 상세 페이지에서 신청을 진행해주세요.
-            </p>
-            <Button
-              className="mt-5"
-              fullWidth
-              onClick={() =>
-                volunteerId
-                  ? navigate(getVolunteerDetailPath(volunteerId))
-                  : navigate(ROUTE_PATHS.activitySocialVolunteer)
-              }
-            >
-              상세 페이지로 돌아가기
-            </Button>
-          </section>
+          <div className="flex flex-col items-center justify-center text-center">
+            <div className="w-full rounded-card bg-white p-6 shadow-card">
+              <h2 className="text-[20px] leading-[30px] font-bold tracking-[-0.02em] text-font-main">
+                신청 완료 정보를 찾을 수 없어요
+              </h2>
+              <p className="mt-2 text-[12px] leading-6 font-medium tracking-[-0.02em] text-font-sub">
+                직접 진입한 경우일 수 있어요. 봉사 상세 페이지로 돌아가 다시 확인해주세요.
+              </p>
+              <div className="mt-6">
+                <Button
+                  fullWidth
+                  onClick={() =>
+                    volunteerId
+                      ? navigate(getVolunteerDetailPath(volunteerId))
+                      : navigate(ROUTE_PATHS.activitySocialVolunteer)
+                  }
+                >
+                  상세 페이지로 돌아가기
+                </Button>
+              </div>
+            </div>
+            <div className="mt-6 w-full">
+              <Button
+                fullWidth
+                variant="primary"
+                onClick={() => navigate(ROUTE_PATHS.home, { replace: true })}
+              >
+                메인으로 가기
+              </Button>
+            </div>
+          </div>
         )}
       </section>
     </MainLayout>

--- a/src/pages/esg/social/VolunteerDetailPage.tsx
+++ b/src/pages/esg/social/VolunteerDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { BottomActionBar, IconButton } from '../../../components/common'
+import { BottomActionBar, Button, IconButton } from '../../../components/common'
 import { Icons } from '../../../components/common'
 import Header from '../../../components/layout/Header'
 import MainLayout from '../../../components/layout/MainLayout'
@@ -47,11 +47,11 @@ export function VolunteerDetailPage() {
   const navigate = useNavigate()
   const { volunteerId } = useParams()
   const parsedVolunteerId = Number(volunteerId)
-  const [volunteerDetail, setVolunteerDetail] = useState<VolunteerDetail | null>(
-    null,
-  )
+  const [volunteerDetail, setVolunteerDetail] =
+    useState<VolunteerDetail | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState('')
+  const [isApplyModalOpen, setIsApplyModalOpen] = useState(false)
 
   const requestVolunteerDetail = useCallback(async () => {
     if (!Number.isInteger(parsedVolunteerId) || parsedVolunteerId <= 0) {
@@ -69,7 +69,9 @@ export function VolunteerDetailPage() {
       setVolunteerDetail(response)
     } catch (fetchError) {
       console.error(fetchError)
-      setError('봉사활동 상세 정보를 불러오지 못했어요. 잠시 후 다시 시도해주세요.')
+      setError(
+        '봉사활동 상세 정보를 불러오지 못했어요. 잠시 후 다시 시도해주세요.',
+      )
     } finally {
       setIsLoading(false)
     }
@@ -152,53 +154,53 @@ export function VolunteerDetailPage() {
 
               <section className="bg-white px-[24px] py-6">
                 <div className="space-y-5">
-                <div className="flex items-start justify-between gap-5">
-                  <p className="shrink-0 text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
-                    모집기관
-                  </p>
-                  <p className="text-right text-sm leading-6 font-normal tracking-[-0.02em] text-gray-600">
-                    {volunteerDetail.organization}
-                  </p>
-                </div>
+                  <div className="flex items-start justify-between gap-5">
+                    <p className="shrink-0 text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
+                      모집기관
+                    </p>
+                    <p className="text-right text-sm leading-6 font-normal tracking-[-0.02em] text-gray-600">
+                      {volunteerDetail.organization}
+                    </p>
+                  </div>
 
-                <div className="flex items-start justify-between gap-5">
-                  <p className="shrink-0 text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
-                    봉사장소
-                  </p>
-                  <p className="text-right text-sm leading-6 font-normal tracking-[-0.02em] text-gray-600">
-                    {volunteerDetail.location}
-                  </p>
-                </div>
+                  <div className="flex items-start justify-between gap-5">
+                    <p className="shrink-0 text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
+                      봉사장소
+                    </p>
+                    <p className="text-right text-sm leading-6 font-normal tracking-[-0.02em] text-gray-600">
+                      {volunteerDetail.location}
+                    </p>
+                  </div>
 
-                <div className="flex items-start justify-between gap-5">
-                  <p className="shrink-0 text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
-                    봉사날짜
-                  </p>
-                  <p className="text-right text-sm leading-6 font-normal tracking-[-0.02em] text-gray-600">
-                    {formatVolunteerDate(volunteerDetail.activityDate)}
-                  </p>
-                </div>
+                  <div className="flex items-start justify-between gap-5">
+                    <p className="shrink-0 text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
+                      봉사날짜
+                    </p>
+                    <p className="text-right text-sm leading-6 font-normal tracking-[-0.02em] text-gray-600">
+                      {formatVolunteerDate(volunteerDetail.activityDate)}
+                    </p>
+                  </div>
 
-                <div className="flex items-start justify-between gap-5">
-                  <p className="shrink-0 text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
-                    봉사시간
-                  </p>
-                  <p className="text-right text-sm leading-6 font-normal tracking-[-0.02em] text-gray-600">
-                    {formatVolunteerTimeRange(
-                      volunteerDetail.activityDate,
-                      volunteerDetail.volunteerHour,
-                    )}
-                  </p>
-                </div>
+                  <div className="flex items-start justify-between gap-5">
+                    <p className="shrink-0 text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
+                      봉사시간
+                    </p>
+                    <p className="text-right text-sm leading-6 font-normal tracking-[-0.02em] text-gray-600">
+                      {formatVolunteerTimeRange(
+                        volunteerDetail.activityDate,
+                        volunteerDetail.volunteerHour,
+                      )}
+                    </p>
+                  </div>
 
-                <div className="flex items-start justify-between gap-5">
-                  <p className="shrink-0 text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
-                    모집인원
-                  </p>
-                  <p className="text-right text-sm leading-6 font-normal tracking-[-0.02em] text-gray-600">
-                    {volunteerDetail.capacity}명
-                  </p>
-                </div>
+                  <div className="flex items-start justify-between gap-5">
+                    <p className="shrink-0 text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
+                      모집인원
+                    </p>
+                    <p className="text-right text-sm leading-6 font-normal tracking-[-0.02em] text-gray-600">
+                      {volunteerDetail.capacity}명
+                    </p>
+                  </div>
                 </div>
               </section>
 
@@ -217,12 +219,63 @@ export function VolunteerDetailPage() {
           leftText={
             <>
               <span className="text-gray-400">신청인원 </span>
-              <span className="text-primary-400">{volunteerDetail.currentEnrolled}</span>
-              <span className="text-gray-600"> / {volunteerDetail.capacity}명</span>
+              <span className="text-primary-400">
+                {volunteerDetail.currentEnrolled}
+              </span>
+              <span className="text-gray-600">
+                {' '}
+                / {volunteerDetail.capacity}명
+              </span>
             </>
           }
           buttonLabel="신청하기"
+          onButtonClick={() => setIsApplyModalOpen(true)}
         />
+      ) : null}
+
+      {isApplyModalOpen ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/35 px-4"
+          onClick={() => setIsApplyModalOpen(false)}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="volunteer-apply-modal-title"
+            className="w-full max-w-[340px] rounded-[8px] bg-white px-5 pt-6 pb-5 shadow-[0_8px_24px_rgba(15,23,42,0.16)]"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <p
+              id="volunteer-apply-modal-title"
+              className="text-center text-lg font-semibold text-font-main"
+            >
+              신청하시겠습니까?
+            </p>
+            <p className="mt-2 text-center text-sm leading-6 text-gray-400">
+              봉사 시작 24시간 전까지는 취소할 수 있으며,
+              <br />
+              노쇼 시 이용 제한 및 패널티가 발생할 수 있습니다.
+            </p>
+
+            <div className="mt-5 flex gap-3">
+              <Button
+                variant="gray"
+                fullWidth
+                className="!rounded-[8px]"
+                onClick={() => setIsApplyModalOpen(false)}
+              >
+                아니요
+              </Button>
+              <Button
+                fullWidth
+                className="!rounded-[8px]"
+                onClick={() => setIsApplyModalOpen(false)}
+              >
+                네
+              </Button>
+            </div>
+          </div>
+        </div>
       ) : null}
     </MainLayout>
   )

--- a/src/pages/esg/social/VolunteerDetailPage.tsx
+++ b/src/pages/esg/social/VolunteerDetailPage.tsx
@@ -1,0 +1,29 @@
+import { useNavigate } from 'react-router-dom'
+import { IconButton } from '../../../components/common'
+import { Icons } from '../../../components/common'
+import Header from '../../../components/layout/Header'
+import MainLayout from '../../../components/layout/MainLayout'
+import { ROUTE_PATHS } from '../../../constants/routePaths'
+
+export function VolunteerDetailPage() {
+  const navigate = useNavigate()
+
+  return (
+    <MainLayout
+      header={
+        <Header
+          left={
+            <IconButton
+              label="뒤로가기"
+              icon={<Icons.Back className="text-font-main" />}
+              onClick={() => navigate(ROUTE_PATHS.activitySocialVolunteer)}
+            />
+          }
+          title="봉사"
+        />
+      }
+    >
+      <section className="pt-2" />
+    </MainLayout>
+  )
+}

--- a/src/pages/esg/social/VolunteerDetailPage.tsx
+++ b/src/pages/esg/social/VolunteerDetailPage.tsx
@@ -4,9 +4,18 @@ import { BottomActionBar, Button, IconButton } from '../../../components/common'
 import { Icons } from '../../../components/common'
 import Header from '../../../components/layout/Header'
 import MainLayout from '../../../components/layout/MainLayout'
-import { ROUTE_PATHS } from '../../../constants/routePaths'
-import { getVolunteerDetail } from '../../../services/volunteerService'
-import type { VolunteerDetail } from '../../../types/volunteer'
+import {
+  getVolunteerCompletePath,
+  ROUTE_PATHS,
+} from '../../../constants/routePaths'
+import {
+  applyVolunteer,
+  getVolunteerDetail,
+} from '../../../services/volunteerService'
+import type {
+  VolunteerApplicationResponse,
+  VolunteerDetail,
+} from '../../../types/volunteer'
 
 const formatVolunteerDate = (activityDate: string) => {
   const date = new Date(activityDate)
@@ -52,6 +61,19 @@ export function VolunteerDetailPage() {
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState('')
   const [isApplyModalOpen, setIsApplyModalOpen] = useState(false)
+  const [isApplying, setIsApplying] = useState(false)
+  const [applicationError, setApplicationError] = useState('')
+
+  const isAlreadyApplied = volunteerDetail?.status === 'APPLIED'
+  const isCapacityFull = volunteerDetail
+    ? volunteerDetail.currentEnrolled >= volunteerDetail.capacity
+    : false
+  const isApplyDisabled = isApplying || isCapacityFull || isAlreadyApplied
+  const applyButtonLabel = isAlreadyApplied
+    ? '신청 완료'
+    : isCapacityFull
+      ? '정원 마감'
+      : '신청하기'
 
   const requestVolunteerDetail = useCallback(async () => {
     if (!Number.isInteger(parsedVolunteerId) || parsedVolunteerId <= 0) {
@@ -80,6 +102,36 @@ export function VolunteerDetailPage() {
   useEffect(() => {
     void requestVolunteerDetail()
   }, [requestVolunteerDetail])
+
+  const handleApplyVolunteer = async () => {
+    if (!Number.isInteger(parsedVolunteerId) || parsedVolunteerId <= 0) {
+      return
+    }
+
+    setIsApplying(true)
+    setApplicationError('')
+
+    try {
+      const response: VolunteerApplicationResponse = await applyVolunteer({
+        volunteerId: parsedVolunteerId,
+      })
+      setIsApplyModalOpen(false)
+
+      navigate(getVolunteerCompletePath(response.volunteerId), {
+        replace: true,
+        state: {
+          application: response,
+        },
+      })
+    } catch (applyError) {
+      console.error(applyError)
+      setApplicationError(
+        '봉사 신청에 실패했어요. 잠시 후 다시 시도해주세요.',
+      )
+    } finally {
+      setIsApplying(false)
+    }
+  }
 
   return (
     <MainLayout
@@ -228,8 +280,12 @@ export function VolunteerDetailPage() {
               </span>
             </>
           }
-          buttonLabel="신청하기"
-          onButtonClick={() => setIsApplyModalOpen(true)}
+          buttonLabel={applyButtonLabel}
+          buttonVariant={isApplyDisabled ? 'gray' : 'primary'}
+          buttonDisabled={isApplyDisabled}
+          onButtonClick={
+            isApplyDisabled ? undefined : () => setIsApplyModalOpen(true)
+          }
         />
       ) : null}
 
@@ -262,6 +318,7 @@ export function VolunteerDetailPage() {
                 variant="gray"
                 fullWidth
                 className="!rounded-[8px]"
+                disabled={isApplying}
                 onClick={() => setIsApplyModalOpen(false)}
               >
                 아니요
@@ -269,11 +326,18 @@ export function VolunteerDetailPage() {
               <Button
                 fullWidth
                 className="!rounded-[8px]"
-                onClick={() => setIsApplyModalOpen(false)}
+                disabled={isApplying}
+                onClick={() => void handleApplyVolunteer()}
               >
-                네
+                {isApplying ? '신청 중...' : '네'}
               </Button>
             </div>
+
+            {applicationError ? (
+              <p className="mt-3 text-center text-sm leading-6 text-red-500">
+                {applicationError}
+              </p>
+            ) : null}
           </div>
         </div>
       ) : null}

--- a/src/pages/esg/social/VolunteerDetailPage.tsx
+++ b/src/pages/esg/social/VolunteerDetailPage.tsx
@@ -1,12 +1,83 @@
-import { useNavigate } from 'react-router-dom'
-import { IconButton } from '../../../components/common'
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { BottomActionBar, IconButton } from '../../../components/common'
 import { Icons } from '../../../components/common'
 import Header from '../../../components/layout/Header'
 import MainLayout from '../../../components/layout/MainLayout'
 import { ROUTE_PATHS } from '../../../constants/routePaths'
+import { getVolunteerDetail } from '../../../services/volunteerService'
+import type { VolunteerDetail } from '../../../types/volunteer'
+
+const formatVolunteerDate = (activityDate: string) => {
+  const date = new Date(activityDate)
+
+  if (Number.isNaN(date.getTime())) {
+    return activityDate
+  }
+
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+
+  return `${year}.${month}.${day}`
+}
+
+const formatVolunteerTimeRange = (
+  activityDate: string,
+  volunteerHour: number,
+) => {
+  const startDate = new Date(activityDate)
+
+  if (Number.isNaN(startDate.getTime())) {
+    return `${volunteerHour}시간`
+  }
+
+  const endDate = new Date(startDate)
+  endDate.setHours(endDate.getHours() + volunteerHour)
+
+  const formatTime = (date: Date) =>
+    `${String(date.getHours()).padStart(2, '0')}:${String(
+      date.getMinutes(),
+    ).padStart(2, '0')}`
+
+  return `${formatTime(startDate)} ~ ${formatTime(endDate)}`
+}
 
 export function VolunteerDetailPage() {
   const navigate = useNavigate()
+  const { volunteerId } = useParams()
+  const parsedVolunteerId = Number(volunteerId)
+  const [volunteerDetail, setVolunteerDetail] = useState<VolunteerDetail | null>(
+    null,
+  )
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  const requestVolunteerDetail = useCallback(async () => {
+    if (!Number.isInteger(parsedVolunteerId) || parsedVolunteerId <= 0) {
+      setVolunteerDetail(null)
+      setError('올바른 봉사활동 정보가 아니에요.')
+      setIsLoading(false)
+      return
+    }
+
+    setIsLoading(true)
+    setError('')
+
+    try {
+      const response = await getVolunteerDetail(parsedVolunteerId)
+      setVolunteerDetail(response)
+    } catch (fetchError) {
+      console.error(fetchError)
+      setError('봉사활동 상세 정보를 불러오지 못했어요. 잠시 후 다시 시도해주세요.')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [parsedVolunteerId])
+
+  useEffect(() => {
+    void requestVolunteerDetail()
+  }, [requestVolunteerDetail])
 
   return (
     <MainLayout
@@ -22,8 +93,137 @@ export function VolunteerDetailPage() {
           title="봉사"
         />
       }
+      className="bg-gray-100"
     >
-      <section className="pt-2" />
+      {error ? (
+        <section className="mx-[-16px] flex min-h-[calc(100vh-var(--header-h)-48px)] items-center bg-gray-100 px-4 pb-6">
+          <div className="w-full rounded-card border border-red-100 bg-white px-5 py-6 text-center shadow-card">
+            <h2 className="text-lg font-semibold text-font-main">
+              봉사활동을 불러오지 못했어요
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-font-sub">{error}</p>
+          </div>
+        </section>
+      ) : (
+        <section className="mx-[-16px] min-h-[calc(100vh-var(--header-h)-48px)] bg-gray-100 pt-2 pb-[120px]">
+          {isLoading ? (
+            <div className="space-y-2">
+              <section className="bg-white px-[24px] py-6">
+                <div className="space-y-3">
+                  <div className="h-4 w-24 animate-pulse rounded-full bg-gray-200" />
+                  <div className="h-7 w-4/5 animate-pulse rounded-full bg-gray-300" />
+                </div>
+              </section>
+
+              <section className="bg-white px-[24px] py-6">
+                <div className="space-y-5">
+                  {Array.from({ length: 4 }).map((_, index) => (
+                    <div
+                      key={index}
+                      className="flex items-center justify-between gap-4"
+                    >
+                      <div className="h-4 w-16 animate-pulse rounded-full bg-gray-200" />
+                      <div className="h-4 w-32 animate-pulse rounded-full bg-gray-200" />
+                    </div>
+                  ))}
+                </div>
+              </section>
+
+              <section className="bg-white px-[24px] py-6">
+                <div className="space-y-3">
+                  <div className="h-5 w-full animate-pulse rounded-full bg-gray-200" />
+                  <div className="h-5 w-5/6 animate-pulse rounded-full bg-gray-200" />
+                  <div className="h-5 w-4/6 animate-pulse rounded-full bg-gray-200" />
+                </div>
+              </section>
+            </div>
+          ) : volunteerDetail ? (
+            <div className="space-y-2">
+              <section className="bg-white px-[24px] py-6">
+                <div className="flex flex-col gap-2">
+                  <p className="text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
+                    {volunteerDetail.organization}
+                  </p>
+                  <h2 className="text-[18px] leading-[140%] font-bold tracking-[-0.02em] text-font-main">
+                    {volunteerDetail.name}
+                  </h2>
+                </div>
+              </section>
+
+              <section className="bg-white px-[24px] py-6">
+                <div className="space-y-5">
+                <div className="flex items-start justify-between gap-5">
+                  <p className="shrink-0 text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
+                    모집기관
+                  </p>
+                  <p className="text-right text-sm leading-6 font-normal tracking-[-0.02em] text-gray-600">
+                    {volunteerDetail.organization}
+                  </p>
+                </div>
+
+                <div className="flex items-start justify-between gap-5">
+                  <p className="shrink-0 text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
+                    봉사장소
+                  </p>
+                  <p className="text-right text-sm leading-6 font-normal tracking-[-0.02em] text-gray-600">
+                    {volunteerDetail.location}
+                  </p>
+                </div>
+
+                <div className="flex items-start justify-between gap-5">
+                  <p className="shrink-0 text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
+                    봉사날짜
+                  </p>
+                  <p className="text-right text-sm leading-6 font-normal tracking-[-0.02em] text-gray-600">
+                    {formatVolunteerDate(volunteerDetail.activityDate)}
+                  </p>
+                </div>
+
+                <div className="flex items-start justify-between gap-5">
+                  <p className="shrink-0 text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
+                    봉사시간
+                  </p>
+                  <p className="text-right text-sm leading-6 font-normal tracking-[-0.02em] text-gray-600">
+                    {formatVolunteerTimeRange(
+                      volunteerDetail.activityDate,
+                      volunteerDetail.volunteerHour,
+                    )}
+                  </p>
+                </div>
+
+                <div className="flex items-start justify-between gap-5">
+                  <p className="shrink-0 text-sm leading-[120%] font-medium tracking-[-0.02em] text-gray-400">
+                    모집인원
+                  </p>
+                  <p className="text-right text-sm leading-6 font-normal tracking-[-0.02em] text-gray-600">
+                    {volunteerDetail.capacity}명
+                  </p>
+                </div>
+                </div>
+              </section>
+
+              <section className="bg-white px-[24px] py-6">
+                <p className="whitespace-pre-line text-base leading-8 font-normal tracking-[-0.02em] text-gray-500">
+                  {volunteerDetail.description}
+                </p>
+              </section>
+            </div>
+          ) : null}
+        </section>
+      )}
+
+      {!error && !isLoading && volunteerDetail ? (
+        <BottomActionBar
+          leftText={
+            <>
+              <span className="text-gray-400">신청인원 </span>
+              <span className="text-primary-400">{volunteerDetail.currentEnrolled}</span>
+              <span className="text-gray-600"> / {volunteerDetail.capacity}명</span>
+            </>
+          }
+          buttonLabel="신청하기"
+        />
+      ) : null}
     </MainLayout>
   )
 }

--- a/src/pages/esg/social/VolunteerPage.tsx
+++ b/src/pages/esg/social/VolunteerPage.tsx
@@ -169,7 +169,7 @@ export function VolunteerPage() {
       ) : null}
 
       {!isLoading && !error && volunteerData ? (
-        <section className="mx-[-16px] min-h-[calc(100vh-var(--header-h)-var(--nav-h)-96px)] bg-gray-100 px-4 pt-2 pb-4">
+        <section className="mx-[-16px] min-h-[calc(100vh-var(--header-h)-var(--nav-h)-96px)] bg-gray-100 px-4 pt-2">
           <div className="space-y-4">
             <div className="flex items-center justify-between px-3">
               <h2 className="text-[18px] leading-[120%] font-semibold tracking-[-0.02em] text-font-main">

--- a/src/pages/esg/social/VolunteerPage.tsx
+++ b/src/pages/esg/social/VolunteerPage.tsx
@@ -5,7 +5,10 @@ import { Card, IconButton } from '../../../components/common'
 import { Icons } from '../../../components/common'
 import Header from '../../../components/layout/Header'
 import MainLayout from '../../../components/layout/MainLayout'
-import { ROUTE_PATHS } from '../../../constants/routePaths'
+import {
+  getVolunteerDetailPath,
+  ROUTE_PATHS,
+} from '../../../constants/routePaths'
 import { getVolunteerActivities } from '../../../services/volunteerService'
 import type { VolunteerActivity, VolunteerListResponse } from '../../../types/volunteer'
 import { SocialActivityTabs } from './components/SocialActivityTabs'
@@ -183,6 +186,9 @@ export function VolunteerPage() {
                   key={volunteer.volunteerId}
                   data-volunteer-id={volunteer.volunteerId}
                   className="rounded-control !p-5 shadow-[0_2px_8px_rgba(0,0,0,0.05)]"
+                  onClick={() =>
+                    navigate(getVolunteerDetailPath(volunteer.volunteerId))
+                  }
                 >
                   <div className="flex flex-col gap-3">
                     <div className="flex flex-col gap-1">

--- a/src/pages/esg/social/VolunteerPage.tsx
+++ b/src/pages/esg/social/VolunteerPage.tsx
@@ -1,0 +1,30 @@
+import { useNavigate } from 'react-router-dom'
+import { IconButton } from '../../../components/common'
+import { Icons } from '../../../components/common'
+import Header from '../../../components/layout/Header'
+import MainLayout from '../../../components/layout/MainLayout'
+import { ROUTE_PATHS } from '../../../constants/routePaths'
+import { SocialActivityTabs } from './components/SocialActivityTabs'
+
+export function VolunteerPage() {
+  const navigate = useNavigate()
+
+  return (
+    <MainLayout
+      header={
+        <Header
+          left={
+            <IconButton
+              label="뒤로가기"
+              icon={<Icons.Back className="text-font-main" />}
+              onClick={() => navigate(ROUTE_PATHS.home)}
+            />
+          }
+          title="S 활동"
+        />
+      }
+    >
+      <SocialActivityTabs activeTab="volunteer" />
+    </MainLayout>
+  )
+}

--- a/src/pages/esg/social/VolunteerPage.tsx
+++ b/src/pages/esg/social/VolunteerPage.tsx
@@ -169,7 +169,7 @@ export function VolunteerPage() {
       ) : null}
 
       {!isLoading && !error && volunteerData ? (
-        <section className="mx-[-16px] min-h-[calc(100vh-var(--header-h)-var(--nav-h)-96px)] bg-gray-100 px-4 pt-2">
+        <section className="mx-[-16px] min-h-[calc(100vh-var(--header-h)-var(--nav-h)-96px)] bg-gray-100 px-4">
           <div className="space-y-4">
             <div className="flex items-center justify-between">
               <h2 className="text-[18px] leading-[120%] font-semibold tracking-[-0.02em] text-font-main">

--- a/src/pages/esg/social/VolunteerPage.tsx
+++ b/src/pages/esg/social/VolunteerPage.tsx
@@ -171,7 +171,7 @@ export function VolunteerPage() {
       {!isLoading && !error && volunteerData ? (
         <section className="mx-[-16px] min-h-[calc(100vh-var(--header-h)-var(--nav-h)-96px)] bg-gray-100 px-4 pt-2">
           <div className="space-y-4">
-            <div className="flex items-center justify-between px-3">
+            <div className="flex items-center justify-between">
               <h2 className="text-[18px] leading-[120%] font-semibold tracking-[-0.02em] text-font-main">
                 모집중인 봉사활동
               </h2>

--- a/src/pages/esg/social/VolunteerPage.tsx
+++ b/src/pages/esg/social/VolunteerPage.tsx
@@ -1,13 +1,122 @@
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { IconButton } from '../../../components/common'
+import BottomNavigation from '../../../components/layout/BottomNavigation'
+import { Card, IconButton } from '../../../components/common'
 import { Icons } from '../../../components/common'
 import Header from '../../../components/layout/Header'
 import MainLayout from '../../../components/layout/MainLayout'
 import { ROUTE_PATHS } from '../../../constants/routePaths'
+import { getVolunteerActivities } from '../../../services/volunteerService'
+import type { VolunteerActivity, VolunteerListResponse } from '../../../types/volunteer'
 import { SocialActivityTabs } from './components/SocialActivityTabs'
+
+const formatVolunteerDate = (activityDate: string) => {
+  const date = new Date(activityDate)
+
+  if (Number.isNaN(date.getTime())) {
+    return activityDate
+  }
+
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+
+  return `${year}.${month}.${day}`
+}
+
+const formatVolunteerTimeRange = (
+  activityDate: string,
+  volunteerHour: number,
+) => {
+  const startDate = new Date(activityDate)
+
+  if (Number.isNaN(startDate.getTime())) {
+    return `${volunteerHour}시간`
+  }
+
+  const endDate = new Date(startDate)
+  endDate.setHours(endDate.getHours() + volunteerHour)
+
+  const formatTime = (date: Date) =>
+    `${String(date.getHours()).padStart(2, '0')}:${String(
+      date.getMinutes(),
+    ).padStart(2, '0')}`
+
+  return `${formatTime(startDate)} - ${formatTime(endDate)}`
+}
+
+const formatVolunteerLocation = (location: string) =>
+  location
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .join(' ')
+
+const getVolunteerMetaLabel = (volunteer: VolunteerActivity) =>
+  `${volunteer.organization} | ${formatVolunteerLocation(volunteer.location)}`
 
 export function VolunteerPage() {
   const navigate = useNavigate()
+  const [volunteerData, setVolunteerData] =
+    useState<VolunteerListResponse | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let isMounted = true
+
+    const fetchVolunteerActivities = async () => {
+      setIsLoading(true)
+      setError('')
+
+      try {
+        const response = await getVolunteerActivities()
+        if (!isMounted) {
+          return
+        }
+        setVolunteerData(response)
+      } catch (fetchError) {
+        console.error(fetchError)
+        if (!isMounted) {
+          return
+        }
+        setError(
+          '봉사활동 정보를 불러오지 못했어요. 잠시 후 다시 시도해주세요.',
+        )
+      }
+
+      if (isMounted) {
+        setIsLoading(false)
+      }
+    }
+
+    void fetchVolunteerActivities()
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  const handleBottomNavigation = (key: string) => {
+    if (key === 'home') {
+      navigate(ROUTE_PATHS.home)
+      return
+    }
+
+    if (key === 'benefits') {
+      navigate(ROUTE_PATHS.shop)
+      return
+    }
+
+    if (key === 'finance') {
+      navigate(ROUTE_PATHS.finance)
+      return
+    }
+
+    if (key === 'mypage') {
+      navigate(ROUTE_PATHS.my)
+    }
+  }
 
   return (
     <MainLayout
@@ -23,8 +132,97 @@ export function VolunteerPage() {
           title="S 활동"
         />
       }
+      nav={<BottomNavigation value="home" onChange={handleBottomNavigation} />}
     >
       <SocialActivityTabs activeTab="volunteer" />
+
+      {isLoading ? (
+        <section className="space-y-3 pt-2">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <Card
+              key={index}
+              className="rounded-control !p-4 shadow-[0_2px_8px_rgba(0,0,0,0.05)]"
+            >
+              <div className="space-y-3">
+                <div className="h-3 w-24 animate-pulse rounded-full bg-gray-200" />
+                <div className="h-5 w-2/3 animate-pulse rounded-full bg-gray-300" />
+                <div className="h-4 w-full animate-pulse rounded-full bg-gray-200" />
+                <div className="h-4 w-4/5 animate-pulse rounded-full bg-gray-200" />
+              </div>
+            </Card>
+          ))}
+        </section>
+      ) : null}
+
+      {!isLoading && error ? (
+        <section className="pt-2">
+          <Card className="rounded-card border border-red-100 bg-red-50 px-5 py-6 text-center shadow-card">
+            <h2 className="text-lg font-semibold text-font-main">
+              봉사활동을 불러오지 못했어요
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-font-sub">{error}</p>
+          </Card>
+        </section>
+      ) : null}
+
+      {!isLoading && !error && volunteerData ? (
+        <section className="mx-[-16px] min-h-[calc(100vh-var(--header-h)-var(--nav-h)-96px)] bg-gray-100 px-4 pt-2 pb-4">
+          <div className="space-y-4">
+            <div className="flex items-center justify-between px-3">
+              <h2 className="text-[18px] leading-[120%] font-semibold tracking-[-0.02em] text-font-main">
+                모집중인 봉사활동
+              </h2>
+              <span className="text-sm leading-[120%] font-medium tracking-[-0.02em] text-primary-400">
+                {volunteerData.volunteers.length}건
+              </span>
+            </div>
+
+            <div className="space-y-4">
+              {volunteerData.volunteers.map((volunteer) => (
+                <Card
+                  key={volunteer.volunteerId}
+                  data-volunteer-id={volunteer.volunteerId}
+                  className="rounded-control !p-5 shadow-[0_2px_8px_rgba(0,0,0,0.05)]"
+                >
+                  <div className="flex flex-col gap-3">
+                    <div className="flex flex-col gap-1">
+                      <p className="text-sm leading-[120%] font-medium tracking-[-0.02em] text-font-sub">
+                        {getVolunteerMetaLabel(volunteer)}
+                      </p>
+                      <h3 className="text-[18px] leading-[120%] font-bold tracking-[-0.02em] text-font-main">
+                        {volunteer.name}
+                      </h3>
+                    </div>
+
+                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                      <div className="flex items-center gap-1">
+                        <span className="text-xs leading-[120%] font-medium tracking-[-0.02em] text-primary-400">
+                          봉사날짜
+                        </span>
+                        <span className="text-xs leading-[120%] font-normal tracking-[-0.02em] text-font-sub">
+                          {formatVolunteerDate(volunteer.activityDate)}
+                        </span>
+                      </div>
+
+                      <div className="flex items-center gap-1">
+                        <span className="text-xs leading-[120%] font-medium tracking-[-0.02em] text-primary-400">
+                          봉사시간
+                        </span>
+                        <span className="text-xs leading-[120%] font-normal tracking-[-0.02em] text-font-sub">
+                          {formatVolunteerTimeRange(
+                            volunteer.activityDate,
+                            volunteer.volunteerHour,
+                          )}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </Card>
+              ))}
+            </div>
+          </div>
+        </section>
+      ) : null}
     </MainLayout>
   )
 }

--- a/src/pages/esg/social/components/SocialActivityTabs.tsx
+++ b/src/pages/esg/social/components/SocialActivityTabs.tsx
@@ -12,7 +12,11 @@ const tabItems = [
     path: ROUTE_PATHS.activitySocialDonation,
   },
   { value: 'store', label: '가치가게', path: ROUTE_PATHS.activitySocialStore },
-  { value: 'volunteer', label: '봉사', path: undefined },
+  {
+    value: 'volunteer',
+    label: '봉사',
+    path: ROUTE_PATHS.activitySocialVolunteer,
+  },
 ] as const
 
 export const SocialActivityTabs = ({ activeTab }: SocialActivityTabsProps) => {

--- a/src/pages/finance/FinancePage.tsx
+++ b/src/pages/finance/FinancePage.tsx
@@ -1,4 +1,5 @@
-﻿import { useNavigate } from 'react-router-dom'
+﻿import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { Badge, Card, Icons, SectionHeader } from '../../components/common'
 import BottomNavigation from '../../components/layout/BottomNavigation'
 import MainLayout from '../../components/layout/MainLayout'
@@ -8,10 +9,12 @@ import {
 } from '../../constants/bottomNavigation'
 import { ROUTE_PATHS, getFinanceDetailPath } from '../../constants/routePaths'
 import { financeSectionLabels, loanProducts, savingsProducts } from './financeData'
+import { FinanceTabs } from './components/FinanceTabs'
 import { ShopHeader } from '../shop/components/ShopHeader'
 
 export const FinancePage = () => {
   const navigate = useNavigate()
+  const [activeTab, setActiveTab] = useState<'all' | 'savings' | 'loan'>('all')
 
   const handleBottomNavigation = (key: string) => {
     const nextPath =
@@ -33,6 +36,8 @@ export const FinancePage = () => {
 
   const loanProduct = loanProducts[0]
   const loanTiers = loanProduct?.loanTiers ?? []
+  const showSavingsSection = activeTab === 'all' || activeTab === 'savings'
+  const showLoanSection = activeTab === 'all' || activeTab === 'loan'
 
   return (
     <MainLayout
@@ -46,8 +51,11 @@ export const FinancePage = () => {
       }
       className="bg-bg-light"
     >
-      <div className="-mx-4 flex flex-col gap-4 bg-bg-light px-(--side-padding) pt-4 pb-2">
-        <section className="flex flex-col gap-4">
+      <div className="-mx-4 flex flex-col gap-4 bg-bg-light px-(--side-padding) pb-2">
+        <FinanceTabs activeTab={activeTab} onChange={setActiveTab} />
+
+        {showSavingsSection ? (
+          <section className="flex flex-col gap-4">
           <SectionHeader
             title={
               <span className="text-lg leading-[120%] font-semibold text-gray-700">
@@ -84,9 +92,11 @@ export const FinancePage = () => {
               </Card>
             ))}
           </div>
-        </section>
+          </section>
+        ) : null}
 
-        <section className="flex flex-col gap-4">
+        {showLoanSection ? (
+          <section className="flex flex-col gap-4">
           <SectionHeader
             title={
               <span className="text-lg leading-[120%] font-semibold text-gray-700">
@@ -152,7 +162,8 @@ export const FinancePage = () => {
               ) : null}
             </Card>
           ) : null}
-        </section>
+          </section>
+        ) : null}
       </div>
     </MainLayout>
   )

--- a/src/pages/finance/FinancePage.tsx
+++ b/src/pages/finance/FinancePage.tsx
@@ -46,12 +46,15 @@ export const FinancePage = () => {
       }
       className="bg-bg-light"
     >
-      <div className="-mx-4 flex flex-col gap-10 bg-bg-light px-(--side-padding) pb-2">
-        <section className="flex flex-col gap-3">
+      <div className="-mx-4 flex flex-col gap-4 bg-bg-light px-(--side-padding) pt-4 pb-2">
+        <section className="flex flex-col gap-4">
           <SectionHeader
-            title={financeSectionLabels.SAVINGS}
+            title={
+              <span className="text-lg leading-[120%] font-semibold text-gray-700">
+                {financeSectionLabels.SAVINGS}
+              </span>
+            }
             right={<span className="text-sm font-medium text-primary-400">{savingsProducts.length}건</span>}
-            className="px-3"
           />
 
           <div className="flex flex-col gap-3">
@@ -83,11 +86,14 @@ export const FinancePage = () => {
           </div>
         </section>
 
-        <section className="flex flex-col gap-3">
+        <section className="flex flex-col gap-4">
           <SectionHeader
-            title={financeSectionLabels.LOAN}
+            title={
+              <span className="text-lg leading-[120%] font-semibold text-gray-700">
+                {financeSectionLabels.LOAN}
+              </span>
+            }
             right={<span className="text-sm font-medium text-primary-400">{loanProducts.length}건</span>}
-            className="px-3"
           />
 
           {loanProduct ? (

--- a/src/pages/finance/components/FinanceTabs.tsx
+++ b/src/pages/finance/components/FinanceTabs.tsx
@@ -1,0 +1,46 @@
+interface FinanceTabsProps {
+  activeTab: 'all' | 'savings' | 'loan'
+  onChange: (tab: 'all' | 'savings' | 'loan') => void
+}
+
+const tabItems = [
+  { value: 'all', label: '전체' },
+  { value: 'savings', label: '적금 상품' },
+  { value: 'loan', label: '대출 상품' },
+] as const
+
+export const FinanceTabs = ({ activeTab, onChange }: FinanceTabsProps) => {
+  return (
+    <div className="sticky top-(--header-h) z-40 mx-[-16px] flex border-b border-gray-200 bg-white">
+      {tabItems.map((item) => {
+        const isActive = item.value === activeTab
+
+        return (
+          <button
+            type="button"
+            key={item.value}
+            role="tab"
+            aria-selected={isActive}
+            onClick={() => {
+              if (!isActive) {
+                onChange(item.value)
+              }
+            }}
+            className={`relative flex h-12 w-1/3 items-center justify-center transition-colors ${
+              isActive ? 'text-font-main' : 'text-gray-400'
+            }`}
+          >
+            <span className="text-base font-semibold tracking-[-0.02em]">
+              {item.label}
+            </span>
+            <span
+              className={`absolute inset-x-0 bottom-0 h-px transition-colors ${
+                isActive ? 'bg-primary-500' : 'bg-transparent'
+              }`}
+            />
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/pages/shop/ShopListPage.tsx
+++ b/src/pages/shop/ShopListPage.tsx
@@ -121,7 +121,6 @@ export const ShopListPage = () => {
 
         <div className="flex flex-col gap-[var(--space-4)] bg-bg-light px-(--side-padding) pb-[var(--space-4)]">
           <SectionHeader
-            className="py-[var(--space-1)]"
             title={<span className="text-lg font-semibold text-gray-700">상품 목록</span>}
             right={
               <div className="flex shrink-0 items-center gap-[var(--space-2)] whitespace-nowrap">

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -21,6 +21,7 @@ import { ValueStorePaymentCompletePage } from '../pages/esg/social/ValueStorePay
 import { ValueStorePaymentPage } from '../pages/esg/social/ValueStorePaymentPage'
 import { ValueStorePaymentRedirectPage } from '../pages/esg/social/ValueStorePaymentRedirectPage'
 import { ValueStorePage } from '../pages/esg/social/ValueStorePage'
+import { VolunteerPage } from '../pages/esg/social/VolunteerPage'
 
 import { LoginPage } from '../pages/auth/LoginPage'
 import { OnboardingPage } from '../pages/auth/OnboardingPage'
@@ -108,6 +109,10 @@ function AppRoutes() {
           <Route
             path={ROUTE_PATHS.activitySocialStore}
             element={<ValueStorePage />}
+          />
+          <Route
+            path={ROUTE_PATHS.activitySocialVolunteer}
+            element={<VolunteerPage />}
           />
           <Route
             path={ROUTE_PATHS.activitySocialProductDetail}

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -21,6 +21,7 @@ import { ValueStorePaymentCompletePage } from '../pages/esg/social/ValueStorePay
 import { ValueStorePaymentPage } from '../pages/esg/social/ValueStorePaymentPage'
 import { ValueStorePaymentRedirectPage } from '../pages/esg/social/ValueStorePaymentRedirectPage'
 import { ValueStorePage } from '../pages/esg/social/ValueStorePage'
+import { VolunteerDetailPage } from '../pages/esg/social/VolunteerDetailPage'
 import { VolunteerPage } from '../pages/esg/social/VolunteerPage'
 
 import { LoginPage } from '../pages/auth/LoginPage'
@@ -113,6 +114,10 @@ function AppRoutes() {
           <Route
             path={ROUTE_PATHS.activitySocialVolunteer}
             element={<VolunteerPage />}
+          />
+          <Route
+            path={ROUTE_PATHS.activitySocialVolunteerDetail}
+            element={<VolunteerDetailPage />}
           />
           <Route
             path={ROUTE_PATHS.activitySocialProductDetail}

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -21,6 +21,7 @@ import { ValueStorePaymentCompletePage } from '../pages/esg/social/ValueStorePay
 import { ValueStorePaymentPage } from '../pages/esg/social/ValueStorePaymentPage'
 import { ValueStorePaymentRedirectPage } from '../pages/esg/social/ValueStorePaymentRedirectPage'
 import { ValueStorePage } from '../pages/esg/social/ValueStorePage'
+import { VolunteerCompletePage } from '../pages/esg/social/VolunteerCompletePage'
 import { VolunteerDetailPage } from '../pages/esg/social/VolunteerDetailPage'
 import { VolunteerPage } from '../pages/esg/social/VolunteerPage'
 
@@ -118,6 +119,10 @@ function AppRoutes() {
           <Route
             path={ROUTE_PATHS.activitySocialVolunteerDetail}
             element={<VolunteerDetailPage />}
+          />
+          <Route
+            path={ROUTE_PATHS.activitySocialVolunteerComplete}
+            element={<VolunteerCompletePage />}
           />
           <Route
             path={ROUTE_PATHS.activitySocialProductDetail}

--- a/src/services/volunteerService.ts
+++ b/src/services/volunteerService.ts
@@ -1,0 +1,7 @@
+import { apiClient } from './apiClient'
+import type { VolunteerListResponse } from '../types/volunteer'
+
+export const getVolunteerActivities = async (): Promise<VolunteerListResponse> => {
+  const response = await apiClient.get<VolunteerListResponse>('/v1/esg/s/volunteers')
+  return response.data
+}

--- a/src/services/volunteerService.ts
+++ b/src/services/volunteerService.ts
@@ -1,7 +1,16 @@
 import { apiClient } from './apiClient'
-import type { VolunteerListResponse } from '../types/volunteer'
+import type { VolunteerDetail, VolunteerListResponse } from '../types/volunteer'
 
 export const getVolunteerActivities = async (): Promise<VolunteerListResponse> => {
   const response = await apiClient.get<VolunteerListResponse>('/v1/esg/s/volunteers')
+  return response.data
+}
+
+export const getVolunteerDetail = async (
+  volunteerId: number,
+): Promise<VolunteerDetail> => {
+  const response = await apiClient.get<VolunteerDetail>(
+    `/v1/esg/s/volunteers/${volunteerId}`,
+  )
   return response.data
 }

--- a/src/services/volunteerService.ts
+++ b/src/services/volunteerService.ts
@@ -1,5 +1,10 @@
 import { apiClient } from './apiClient'
-import type { VolunteerDetail, VolunteerListResponse } from '../types/volunteer'
+import type {
+  ApplyVolunteerRequest,
+  VolunteerApplicationResponse,
+  VolunteerDetail,
+  VolunteerListResponse,
+} from '../types/volunteer'
 
 export const getVolunteerActivities = async (): Promise<VolunteerListResponse> => {
   const response = await apiClient.get<VolunteerListResponse>('/v1/esg/s/volunteers')
@@ -11,6 +16,16 @@ export const getVolunteerDetail = async (
 ): Promise<VolunteerDetail> => {
   const response = await apiClient.get<VolunteerDetail>(
     `/v1/esg/s/volunteers/${volunteerId}`,
+  )
+  return response.data
+}
+
+export const applyVolunteer = async (
+  payload: ApplyVolunteerRequest,
+): Promise<VolunteerApplicationResponse> => {
+  const response = await apiClient.post<VolunteerApplicationResponse>(
+    '/v1/esg/s/volunteers/apply',
+    payload,
   )
   return response.data
 }

--- a/src/types/volunteer.ts
+++ b/src/types/volunteer.ts
@@ -8,10 +8,24 @@ export interface VolunteerActivity {
   currentEnrolled: number
   volunteerHour: number
   organization: string
+  status: 'APPLIED' | null
 }
 
 export type VolunteerDetail = VolunteerActivity
 
 export interface VolunteerListResponse {
   volunteers: VolunteerActivity[]
+}
+
+export interface ApplyVolunteerRequest {
+  volunteerId: number
+}
+
+export interface VolunteerApplicationResponse {
+  volunteerApplicationId: number
+  volunteerId: number
+  name: string
+  location: string
+  activityDate: string
+  status: 'APPLIED'
 }

--- a/src/types/volunteer.ts
+++ b/src/types/volunteer.ts
@@ -1,0 +1,15 @@
+export interface VolunteerActivity {
+  volunteerId: number
+  name: string
+  description: string
+  activityDate: string
+  location: string
+  capacity: number
+  currentEnrolled: number
+  volunteerHour: number
+  organization: string
+}
+
+export interface VolunteerListResponse {
+  volunteers: VolunteerActivity[]
+}

--- a/src/types/volunteer.ts
+++ b/src/types/volunteer.ts
@@ -10,6 +10,8 @@ export interface VolunteerActivity {
   organization: string
 }
 
+export type VolunteerDetail = VolunteerActivity
+
 export interface VolunteerListResponse {
   volunteers: VolunteerActivity[]
 }


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이슈 번호를 적어주세요. 머지 시 자동으로 이슈가 닫힙니다. -->
Closes #56 

## 📌 작업 내용
<!-- 어떤 작업을 했는지 간단히 설명 -->
- S 활동 내 봉사 페이지를 추가하고 봉사 목록, 상세, 신청 완료 흐름을 구현했습니다.
- 봉사활동 목록/상세 조회 API와 봉사 신청 API를 연동했습니다.
- 봉사 신청 확인 모달과 신청 완료 페이지 UI를 추가했습니다.
- 금융상품 페이지에 탭 전환 UI를 추가하고 목록형 페이지들의 섹션 여백을 통일했습니다.
- 포인트샵, 금융상품, S 활동 목록 페이지의 헤더/섹션 간격을 정리했습니다.

## 🛠 변경 사항
<!-- 주요 변경 파일이나 로직을 설명 -->
- src/pages/esg/social/VolunteerPage.tsx 에 봉사활동 목록 페이지를 구현하고 /api/v1/esg/s/volunteers 응답을 카드 형태로 렌더링하도록 추가했습니다.
- src/pages/esg/social/VolunteerDetailPage.tsx 에 봉사활동 상세 조회 UI를 구현하고 /api/v1/esg/s/volunteers/{volunteerId} 연동을 추가했습니다.
- src/pages/esg/social/VolunteerCompletePage.tsx 에 봉사 신청 완료 페이지를 추가했습니다.
- src/pages/esg/social/components/SocialActivityTabs.tsx 에서 봉사 탭 이동을 연결했습니다.
- src/services/volunteerService.ts 에 봉사 목록 조회, 상세 조회, 신청 API 호출 로직을 추가했습니다.
- src/types/volunteer.ts 에 봉사 목록/상세/신청 응답 타입을 추가했습니다.
- src/constants/routePaths.ts 와 src/routes/Router.tsx 에 봉사 목록, 상세, 완료 페이지 라우트를 추가했습니다.
- src/components/common/BottomActionBar.tsx 는 봉사 상세 하단 신청 영역 표현을 위해 버튼 상태와 ReactNode 텍스트를 받을 수 있도록 확장했습니다.
- src/pages/finance/components/FinanceTabs.tsx 를 추가하고 src/pages/finance/FinancePage.tsx 에 금융상품 탭 UI를 구현했습니다.
- src/pages/shop/ShopListPage.tsx, src/pages/finance/FinancePage.tsx, src/pages/esg/social/DonationPage.tsx, src/pages/esg/social/ValueStorePage.tsx, src/pages/esg/social/VolunteerPage.tsx 의 섹션 헤더 위아래 여백을 16px 기준으로 정리했습니다.

## ✅ 테스트 결과
<!-- 테스트를 어떻게 했는지 (로컬 실행, API 테스트 등) -->
- [x] 로컬에서 정상 동작 확인
- [x] API 테스트 완료 (해당되면)
- [x] 빌드 에러 없음

## 📸 스크린샷
<!-- UI 변경이 있으면 스크린샷 첨부 -->

## 💡 리뷰어에게
<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분 -->
