### PR TITLE
66 feat esg 활동 보고서 화면 구현

### DIFF
--- a/src/constants/routePaths.ts
+++ b/src/constants/routePaths.ts
@@ -46,6 +46,7 @@ export const ROUTE_PATHS = {
   myFinanceLoanHistory: '/my/finance/loan',
   myPointManage: '/my/point-manage',
   myReport: '/my/report',
+  reportVerify: '/report/verify/:token',
   chatbot: '/chatbot',
   recommend: '/recommend',
 } as const
@@ -92,3 +93,6 @@ export const getShopDetailPath = (productId: string) => `/shop/${productId}`
 
 export const getEnvVerifyPath = (activityType: string) =>
   `/esg/env/verify?type=${encodeURIComponent(activityType)}`
+
+export const getReportVerifyPath = (token: string) =>
+  `/report/verify/${encodeURIComponent(token)}`

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -27,7 +27,7 @@ const menuItems = [
   },
   {
     key: 'report',
-    label: 'ESG 활동 보고서',
+    label: 'ESG 활동 인증서',
     icon: <FileChartColumn size={18} />,
     path: ROUTE_PATHS.myReport,
   },

--- a/src/pages/my/MyPointManagePage.tsx
+++ b/src/pages/my/MyPointManagePage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { Card, Icons, SectionHeader } from '../../components/common'
 import BottomNavigation from '../../components/layout/BottomNavigation'
 import MainLayout from '../../components/layout/MainLayout'
+// import { getS3AssetUrl } from '../../constants/assetUrls'
 import {
   BOTTOM_NAVIGATION_ITEMS,
   BOTTOM_NAVIGATION_ROUTE_BY_KEY,
@@ -13,6 +14,7 @@ import type { MyPointHistoryItem } from '../../types/myPoint'
 import { ShopHeader } from '../shop/components/ShopHeader'
 
 const numberFormatter = new Intl.NumberFormat('ko-KR')
+// const pointImageUrl = getS3AssetUrl('point.webp')
 
 const pointSummary = {
   guide: '적립과 사용 내역을 한눈에 확인할 수 있어요',
@@ -111,12 +113,21 @@ export const MyPointManagePage = () => {
     >
       <section className="mt-2 flex flex-col gap-5">
         <Card className="mt-3 !gap-3">
-          <div className="space-y-2">
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-2">
             <p className="text-sm font-medium text-font-sub">현재 보유 포인트</p>
             <p className="text-[34px] leading-none font-semibold tracking-tight text-font-main">
               {numberFormatter.format(totalPoints)}
               <span className="ml-1 text-[20px] font-semibold text-font-sub">P</span>
             </p>
+            </div>
+
+            {/* <img
+              src={pointImageUrl}
+              alt=""
+              aria-hidden="true"
+              className="mt-[-15px] h-[90px] w-[90px] mr-3 shrink-0 object-contain"
+            /> */}
           </div>
 
           <p className="text-sm leading-6 text-font-sub mt-2">{pointSummary.guide}</p>

--- a/src/pages/my/MyReportPage.tsx
+++ b/src/pages/my/MyReportPage.tsx
@@ -1,10 +1,465 @@
-import { PageScaffold } from '../PageScaffold'
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Button, Card } from '../../components/common'
+import BottomNavigation from '../../components/layout/BottomNavigation'
+import { getS3AssetUrl } from '../../constants/assetUrls'
+import MainLayout from '../../components/layout/MainLayout'
+import {
+  BOTTOM_NAVIGATION_ITEMS,
+  BOTTOM_NAVIGATION_ROUTE_BY_KEY,
+} from '../../constants/bottomNavigation'
+import { ROUTE_PATHS } from '../../constants/routePaths'
+import { downloadReportPdf, getReportPreview, issueReport } from '../../services/reportService'
+import type {
+  ReportCertificateMeta,
+  ReportCertificateSnapshot,
+  ReportPeriodType,
+} from '../../types/report'
+import type { UserGrade } from '../../types/user'
+import { ShopHeader } from '../shop/components/ShopHeader'
+
+const PERIOD_OPTIONS: Array<{ label: string; value: ReportPeriodType }> = [
+  { label: '3개월', value: '3M' },
+  { label: '6개월', value: '6M' },
+  { label: '1년', value: '1Y' },
+]
+
+const GRADE_LABELS: Record<UserGrade, string> = {
+  SEED: '씨앗',
+  SPROUT: '새싹',
+  TREE: '나무',
+  FOREST: '숲',
+  EARTH: '지구',
+}
+
+const numberFormatter = new Intl.NumberFormat('ko-KR')
+const todayIssueDate = new Intl.DateTimeFormat('sv-SE', { timeZone: 'Asia/Seoul' }).format(
+  new Date(),
+)
+const reportWatermarkImageUrl = getS3AssetUrl('verified.webp')
+
+const formatDisplayDate = (value: string) => {
+  if (!value) {
+    return '-'
+  }
+
+  const normalized = value.includes('T') ? value.slice(0, 10) : value
+  const [year, month, day] = normalized.split('-')
+
+  if (!year || !month || !day) {
+    return value
+  }
+
+  return `${year}.${month}.${day}`
+}
+
+const getTargetPeriodLabel = (snapshot: ReportCertificateSnapshot) =>
+  `${formatDisplayDate(snapshot.targetStartDate)} ~ ${formatDisplayDate(snapshot.targetEndDate)}`
+
+const getConsecutiveStatusLabel = (snapshot: ReportCertificateSnapshot) => {
+  if (!snapshot.showConsecutiveAchievementBadge || snapshot.consecutiveMaxAchievementMonths <= 0) {
+    return '-'
+  }
+
+  return `${snapshot.consecutiveMaxAchievementMonths}개월`
+}
+
+const getAbsoluteVerificationUrl = (verificationUrl: string) => {
+  if (!verificationUrl) {
+    return ''
+  }
+
+  if (/^https?:\/\//i.test(verificationUrl)) {
+    return verificationUrl
+  }
+
+  return `${window.location.origin}${verificationUrl}`
+}
+
+const downloadBlobFile = (blob: Blob, fileName: string) => {
+  const blobUrl = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+
+  anchor.href = blobUrl
+  anchor.download = fileName
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+  URL.revokeObjectURL(blobUrl)
+}
 
 export const MyReportPage = () => {
+  const navigate = useNavigate()
+  const [selectedPeriod, setSelectedPeriod] = useState<ReportPeriodType>('3M')
+  const [reloadCount, setReloadCount] = useState(0)
+  const [report, setReport] = useState<ReportCertificateSnapshot | null>(null)
+  const [issuedMeta, setIssuedMeta] = useState<ReportCertificateMeta | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [isIssuing, setIsIssuing] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [issueErrorMessage, setIssueErrorMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    const fetchReport = async () => {
+      setIsLoading(true)
+      setErrorMessage(null)
+      setIssueErrorMessage(null)
+      setIssuedMeta(null)
+
+      try {
+        const response = await getReportPreview({ periodType: selectedPeriod })
+        if (!cancelled) {
+          setReport(response.snapshot)
+        }
+      } catch {
+        if (!cancelled) {
+          setErrorMessage('인증서 정보를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.')
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    fetchReport()
+
+    return () => {
+      cancelled = true
+    }
+  }, [reloadCount, selectedPeriod])
+
+  const categoryRows = useMemo(() => {
+    if (!report) {
+      return []
+    }
+
+    return report.categories.map((category) => ({
+      ...category,
+      displayValue: `${numberFormatter.format(category.value)}${category.unit}`,
+    }))
+  }, [report])
+
+  const displayIssueDate = issuedMeta ? issuedMeta.issuedAt : todayIssueDate
+  const displayCertificateNumber = issuedMeta?.certificateNumber ?? '발급 후 생성'
+  const displayVerificationCode = issuedMeta?.verificationCode ?? '발급 후 생성'
+  const displayVerificationUrl = issuedMeta
+    ? getAbsoluteVerificationUrl(issuedMeta.verificationUrl)
+    : '인증서 발급 후 확인 가능'
+
+  const handleBottomNavigation = (key: string) => {
+    const nextPath =
+      BOTTOM_NAVIGATION_ROUTE_BY_KEY[key as keyof typeof BOTTOM_NAVIGATION_ROUTE_BY_KEY]
+
+    if (nextPath) {
+      navigate(nextPath)
+    }
+  }
+
+  const handleRetry = () => {
+    setReloadCount((previous) => previous + 1)
+  }
+
+  const handleIssueCertificate = async () => {
+    if (!report || isIssuing) {
+      return
+    }
+
+    setIsIssuing(true)
+    setIssueErrorMessage(null)
+
+    try {
+      const response = await issueReport(selectedPeriod)
+      const normalizedMeta = {
+        ...response.certificate,
+        verificationUrl: getAbsoluteVerificationUrl(response.certificate.verificationUrl),
+      }
+
+      setReport(response.snapshot)
+      setIssuedMeta(normalizedMeta)
+
+      try {
+        const pdfBlob = await downloadReportPdf(response.certificate.issueId)
+        downloadBlobFile(pdfBlob, `ESG_certificate_${response.certificate.certificateNumber}.pdf`)
+      } catch (pdfError) {
+        console.error('Certificate PDF download failed:', pdfError)
+        setIssueErrorMessage('인증서 발급은 완료되었지만 PDF 다운로드에 실패했습니다.')
+      }
+    } catch (issueError) {
+      console.error('Certificate issue failed:', issueError)
+      setIssueErrorMessage('인증서 발급에 실패했습니다. 잠시 후 다시 시도해 주세요.')
+    } finally {
+      setIsIssuing(false)
+    }
+  }
+
   return (
-    <PageScaffold
-      title="ESG 활동 보고서"
-      description="기간별 ESG 활동 요약 보고서를 생성하고 다운로드하는 화면입니다."
-    />
+    <MainLayout
+      header={<ShopHeader title="ESG 활동 인증서" onBack={() => navigate(ROUTE_PATHS.my)} />}
+      nav={
+        <BottomNavigation
+          items={BOTTOM_NAVIGATION_ITEMS}
+          value="my"
+          onChange={handleBottomNavigation}
+        />
+      }
+      className="bg-bg-light"
+    >
+      <section className="mt-5 flex flex-col gap-2 pb-3">
+        <div className="flex items-center justify-between gap-3 px-1">
+          <div className="flex flex-wrap gap-2">
+            {PERIOD_OPTIONS.map((option) => {
+              const isSelected = option.value === selectedPeriod
+
+              return (
+                <Button
+                  key={option.value}
+                  variant={isSelected ? 'sub' : 'gray'}
+                  size="sm"
+                  className={
+                    isSelected
+                      ? '!h-[34px] !px-3 !text-xs !font-semibold'
+                      : '!h-[34px] !border !border-gray-200 !bg-white !px-3 !text-xs !font-medium !text-font-sub'
+                  }
+                  onClick={() => setSelectedPeriod(option.value)}
+                >
+                  {option.label}
+                </Button>
+              )
+            })}
+          </div>
+
+          <Button
+            variant="primary"
+            size="sm"
+            className="!h-[38px] !px-4 !text-xs !font-semibold disabled:!border disabled:!border-primary-200 disabled:!bg-primary-50 disabled:!text-primary-500"
+            disabled={isLoading || !report || isIssuing}
+            onClick={handleIssueCertificate}
+          >
+            {isIssuing ? '인증서 발급 중...' : '인증서 발급받기'}
+          </Button>
+        </div>
+
+        {issueErrorMessage ? (
+          <p className="px-1 text-xs font-medium text-red-500">{issueErrorMessage}</p>
+        ) : null}
+
+        <div className="mx-auto mt-1 w-full max-w-[560px]">
+          {isLoading ? (
+            <Card className="!gap-0 !overflow-hidden !border border-gray-200 !bg-white !p-0 shadow-[0_18px_45px_rgba(15,23,42,0.08)]">
+              <div className="border-b border-gray-100 px-6 pt-6 pb-4">
+                <div className="mx-auto h-7 w-44 animate-pulse rounded bg-gray-100" />
+              </div>
+
+              <div className="space-y-6 px-6 py-6">
+                <div className="space-y-2">
+                  <div className="h-3 w-16 animate-pulse rounded bg-gray-100" />
+                  <div className="h-6 w-28 animate-pulse rounded bg-gray-100" />
+                </div>
+
+                <div className="overflow-hidden rounded-control border border-gray-200">
+                  <div className="grid grid-cols-2">
+                    {Array.from({ length: 4 }).map((_, index) => (
+                      <div
+                        key={index}
+                        className={[
+                          'space-y-2 px-4 py-4',
+                          index % 2 === 0 ? 'border-r border-gray-100' : '',
+                          index < 2 ? 'border-b border-gray-100' : '',
+                        ]
+                          .filter(Boolean)
+                          .join(' ')}
+                      >
+                        <div className="h-3 w-14 animate-pulse rounded bg-gray-100" />
+                        <div className="h-5 w-16 animate-pulse rounded bg-gray-100" />
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="space-y-3 border-t border-gray-100 pt-6">
+                  {Array.from({ length: 3 }).map((_, index) => (
+                    <div key={index} className="flex items-center justify-between">
+                      <div className="h-4 w-16 animate-pulse rounded bg-gray-100" />
+                      <div className="h-4 w-28 animate-pulse rounded bg-gray-100" />
+                    </div>
+                  ))}
+                </div>
+
+                <div className="space-y-3 border-t border-gray-100 pt-4">
+                  <div className="h-3 w-20 animate-pulse rounded bg-gray-100" />
+                  <div className="grid grid-cols-2 gap-x-6 gap-y-4">
+                    {Array.from({ length: 4 }).map((_, index) => (
+                      <div key={index} className="flex items-center justify-between gap-3 py-1">
+                        <div className="h-4 w-24 animate-pulse rounded bg-gray-100" />
+                        <div className="h-4 w-12 animate-pulse rounded bg-gray-100" />
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              <div className="border-t border-dashed border-gray-200 bg-primary-50/30 px-6 py-5">
+                <div className="grid grid-cols-[1fr_96px] items-center gap-5">
+                  <div className="space-y-3">
+                    {Array.from({ length: 3 }).map((_, index) => (
+                      <div key={index} className="flex items-center justify-between gap-3">
+                        <div className="h-3 w-16 animate-pulse rounded bg-white/70" />
+                        <div className="h-3 w-32 animate-pulse rounded bg-white/70" />
+                      </div>
+                    ))}
+                  </div>
+                  <div className="h-[96px] w-[96px] animate-pulse rounded-control border border-dashed border-gray-300 bg-white/80" />
+                </div>
+              </div>
+            </Card>
+          ) : errorMessage ? (
+            <Card className="!gap-0 !border border-gray-200 !bg-white !p-0 shadow-[0_18px_45px_rgba(15,23,42,0.08)]">
+              <div className="space-y-4 px-6 py-10 text-center">
+                <p className="text-base font-semibold text-font-main">인증서 정보를 불러오지 못했습니다</p>
+                <p className="text-sm text-font-sub">{errorMessage}</p>
+                <div className="flex justify-center">
+                  <Button variant="sub" size="sm" onClick={handleRetry}>
+                    다시 시도
+                  </Button>
+                </div>
+              </div>
+            </Card>
+          ) : report ? (
+            <Card className="!relative !gap-0 !overflow-hidden !border border-gray-200 !bg-white !p-0 shadow-[0_18px_45px_rgba(15,23,42,0.08)]">
+              <img
+                src={reportWatermarkImageUrl}
+                alt=""
+                aria-hidden="true"
+                className="pointer-events-none absolute left-1/2 top-1/2 z-0 w-[280px] -translate-x-1/2 -translate-y-1/2 opacity-[0.07]"
+              />
+
+              <div className="relative z-10 border-b border-gray-100 px-6 py-6">
+                <div className="px-1">
+                  <p className="text-center text-[26px] font-semibold tracking-[-0.02em] text-font-main">
+                    ESG 활동 인증서
+                  </p>
+                  <div className="flex justify-end -mr-1 mt-2 -mb-3">
+                    <p className="text-xs font-medium text-gray-400">
+                      발급일 {formatDisplayDate(displayIssueDate)}
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="relative z-10 px-6 py-6">
+                <div className="px-1">
+                  <p className="text-xs font-medium text-gray-400">발급 대상</p>
+                  <p className="mt-2 text-xl font-semibold leading-none tracking-tight text-font-main">
+                    {report.recipientName}
+                  </p>
+                </div>
+
+                <div className="mt-6 overflow-hidden rounded-control border border-gray-200">
+                  <div className="grid grid-cols-2 bg-white">
+                    <div className="border-r border-b border-gray-100 px-4 py-4">
+                      <p className="text-xs font-medium text-gray-400">현재 등급</p>
+                      <p className="mt-2 text-base font-semibold text-font-main">
+                        {GRADE_LABELS[report.currentGrade]}
+                      </p>
+                    </div>
+                    <div className="border-b border-gray-100 px-4 py-4">
+                      <p className="text-xs font-medium text-gray-400">해당 유저 점수</p>
+                      <p className="mt-2 text-base font-semibold text-font-main">
+                        {numberFormatter.format(report.totalScore)}점
+                      </p>
+                    </div>
+                    <div className="border-r border-gray-100 px-4 py-4">
+                      <p className="text-xs font-medium text-gray-400">인증 활동</p>
+                      <p className="mt-2 text-base font-semibold text-font-main">
+                        {numberFormatter.format(report.verifiedActivityCount)}건
+                      </p>
+                    </div>
+                    <div className="px-4 py-4">
+                      <p className="text-xs font-medium text-gray-400">연속 활동</p>
+                      <p className="mt-2 text-base font-semibold text-font-main">
+                        {getConsecutiveStatusLabel(report)}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="mt-4 space-y-3 border-t border-gray-100 pt-6">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-sm font-medium text-font-sub">대상 기간</span>
+                    <span className="text-sm font-semibold text-font-main">
+                      {getTargetPeriodLabel(report)}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-sm font-medium text-font-sub">발급기관</span>
+                    <span className="text-sm font-semibold text-font-main">SOLVE</span>
+                  </div>
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-sm font-medium text-font-sub">인증서 번호</span>
+                    <span className="text-sm font-semibold text-font-main">
+                      {displayCertificateNumber}
+                    </span>
+                  </div>
+                </div>
+
+                <div className="mt-4 border-t border-gray-100 pt-4">
+                  <p className="text-sm font-medium text-gray-400 -mb-3">
+                    카테고리 요약
+                  </p>
+                  <div className="mt-6 grid grid-cols-2 gap-x-6 gap-y-2">
+                    {categoryRows.map((category) => (
+                      <div
+                        key={category.categoryKey}
+                        className="flex items-center justify-between gap-3 py-1"
+                      >
+                        <span className="text-xs font-medium text-font-main">{category.label}</span>
+                        <span className="text-xs font-semibold text-font-main">
+                          {category.displayValue}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              <div className="relative z-10 border-t border-dashed border-gray-200 bg-primary-50/30 px-6 py-5">
+                <div className="grid grid-cols-[1fr_96px] items-center gap-5">
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="text-xs font-medium text-font-sub">인증 코드</span>
+                      <span className="text-xs font-semibold text-font-main">
+                        {displayVerificationCode}
+                      </span>
+                    </div>
+                    <div className="flex items-start justify-between gap-3">
+                      <span className="text-xs font-medium text-font-sub">인증 URL</span>
+                      <span className="max-w-[255px] break-all text-right text-xs font-medium text-font-main">
+                        {displayVerificationUrl}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="text-xs font-medium text-font-sub">유효 기간</span>
+                      <span className="text-xs font-semibold text-font-main">
+                        발급일로부터 1개월
+                      </span>
+                    </div>
+                  </div>
+
+                  <div className="flex h-[96px] w-[96px] items-center justify-center rounded-control border border-dashed border-gray-300 bg-white/80 text-center">
+                    <div>
+                      <p className="text-[10px] font-medium text-gray-400">인증용</p>
+                      <p className="mt-1 text-[11px] font-semibold text-font-main">QR 코드</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </Card>
+          ) : null}
+        </div>
+      </section>
+    </MainLayout>
   )
 }

--- a/src/pages/report/ReportVerificationPage.tsx
+++ b/src/pages/report/ReportVerificationPage.tsx
@@ -1,0 +1,358 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { Button, Card } from '../../components/common'
+import { ROUTE_PATHS } from '../../constants/routePaths'
+import { verifyReport } from '../../services/reportService'
+import type {
+  ReportCategorySummary,
+  ReportCertificateMeta,
+  ReportCertificateSnapshot,
+  ReportVerificationStatus,
+} from '../../types/report'
+import type { UserGrade } from '../../types/user'
+
+const GRADE_LABELS: Record<UserGrade, string> = {
+  SEED: '씨앗',
+  SPROUT: '새싹',
+  TREE: '나무',
+  FOREST: '숲',
+  EARTH: '지구',
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+  ENVIRONMENT: '환경 활동(E)',
+  VOLUNTEER: '봉사활동(S)',
+  DONATION: '사회공헌 활동(S)',
+  TRUST: '신뢰 활동(G)',
+}
+
+const numberFormatter = new Intl.NumberFormat('ko-KR')
+
+const formatDisplayDate = (value?: string) => {
+  if (!value) {
+    return '-'
+  }
+
+  const normalized = value.includes('T') ? value.slice(0, 10) : value
+  const [year, month, day] = normalized.split('-')
+
+  if (!year || !month || !day) {
+    return value
+  }
+
+  return `${year}.${month}.${day}`
+}
+
+const getStatusTone = (status: ReportVerificationStatus) => {
+  switch (status) {
+    case 'ACTIVE':
+      return {
+        badgeClassName: 'bg-primary-50 text-primary-500 border border-primary-100',
+        title: '유효한 인증서입니다',
+        description: 'SOLVE에서 발급된 ESG 활동 인증서가 정상적으로 확인되었습니다.',
+      }
+    case 'REVOKED':
+      return {
+        badgeClassName: 'bg-amber-50 text-amber-600 border border-amber-100',
+        title: '폐기된 인증서입니다',
+        description: '해당 인증서는 더 이상 유효하지 않습니다. 발급 상태를 다시 확인해 주세요.',
+      }
+    default:
+      return {
+        badgeClassName: 'bg-red-50 text-red-500 border border-red-100',
+        title: '유효하지 않은 인증서입니다',
+        description: '등록되지 않았거나 올바르지 않은 인증 정보입니다.',
+      }
+  }
+}
+
+const getConsecutiveStatusLabel = (snapshot: ReportCertificateSnapshot) => {
+  if (!snapshot.showConsecutiveAchievementBadge || snapshot.consecutiveMaxAchievementMonths <= 0) {
+    return '-'
+  }
+
+  return `${snapshot.consecutiveMaxAchievementMonths}개월`
+}
+
+const getCategoryDisplay = (category: ReportCategorySummary) => ({
+  key: category.categoryKey,
+  label: CATEGORY_LABELS[category.categoryKey] ?? category.label,
+  value: `${numberFormatter.format(category.value)}${category.unit}`,
+})
+
+const VerificationSkeleton = () => (
+  <Card className="!gap-0 !border border-gray-200 !bg-white !p-0 shadow-[0_18px_45px_rgba(15,23,42,0.08)]">
+    <div className="space-y-5 px-6 py-7">
+      <div className="space-y-3 border-b border-gray-100 pb-5 text-center">
+        <div className="mx-auto h-6 w-32 animate-pulse rounded bg-gray-100" />
+        <div className="mx-auto h-4 w-48 animate-pulse rounded bg-gray-100" />
+      </div>
+
+      <div className="space-y-3">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <div key={index} className="flex items-center justify-between gap-4">
+            <div className="h-4 w-20 animate-pulse rounded bg-gray-100" />
+            <div className="h-4 w-32 animate-pulse rounded bg-gray-100" />
+          </div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 border-t border-gray-100 pt-5">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div key={index} className="rounded-control border border-gray-100 px-4 py-4">
+            <div className="h-3 w-16 animate-pulse rounded bg-gray-100" />
+            <div className="mt-3 h-5 w-20 animate-pulse rounded bg-gray-100" />
+          </div>
+        ))}
+      </div>
+    </div>
+  </Card>
+)
+
+const VerificationSummary = ({
+  certificate,
+  snapshot,
+}: {
+  certificate: ReportCertificateMeta
+  snapshot: ReportCertificateSnapshot
+}) => {
+  const categories = snapshot.categories.map(getCategoryDisplay)
+
+  return (
+    <Card className="!gap-0 !border border-gray-200 !bg-white !p-0 shadow-[0_18px_45px_rgba(15,23,42,0.08)]">
+      <div className="border-b border-gray-100 px-6 py-7 text-center">
+        <p className="text-xs font-semibold tracking-[0.18em] text-primary-500">CERTIFICATE</p>
+        <h1 className="mt-2 text-[26px] font-semibold tracking-[-0.02em] text-font-main">
+          ESG 활동 인증서
+        </h1>
+        <p className="mt-3 text-sm text-font-sub">
+          SOLVE에서 발급된 ESG 활동 인증 정보입니다.
+        </p>
+      </div>
+
+      <div className="space-y-6 px-6 py-6">
+        <div className="space-y-3">
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-sm font-medium text-font-sub">발급 대상</span>
+            <span className="text-sm font-semibold text-font-main">{snapshot.recipientName}</span>
+          </div>
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-sm font-medium text-font-sub">인증서 번호</span>
+            <span className="text-sm font-semibold text-font-main">
+              {certificate.certificateNumber}
+            </span>
+          </div>
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-sm font-medium text-font-sub">발급일</span>
+            <span className="text-sm font-semibold text-font-main">
+              {formatDisplayDate(certificate.issuedAt)}
+            </span>
+          </div>
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-sm font-medium text-font-sub">대상 기간</span>
+            <span className="text-sm font-semibold text-font-main">
+              {formatDisplayDate(snapshot.targetStartDate)} ~{' '}
+              {formatDisplayDate(snapshot.targetEndDate)}
+            </span>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3 border-t border-gray-100 pt-5">
+          <div className="rounded-control border border-gray-100 px-4 py-4">
+            <p className="text-xs font-medium text-gray-400">현재 등급</p>
+            <p className="mt-2 text-base font-semibold text-font-main">
+              {GRADE_LABELS[snapshot.currentGrade]}
+            </p>
+          </div>
+          <div className="rounded-control border border-gray-100 px-4 py-4">
+            <p className="text-xs font-medium text-gray-400">해당 유저 점수</p>
+            <p className="mt-2 text-base font-semibold text-font-main">
+              {numberFormatter.format(snapshot.totalScore)}점
+            </p>
+          </div>
+          <div className="rounded-control border border-gray-100 px-4 py-4">
+            <p className="text-xs font-medium text-gray-400">인증 활동</p>
+            <p className="mt-2 text-base font-semibold text-font-main">
+              {numberFormatter.format(snapshot.verifiedActivityCount)}건
+            </p>
+          </div>
+          <div className="rounded-control border border-gray-100 px-4 py-4">
+            <p className="text-xs font-medium text-gray-400">연속 활동</p>
+            <p className="mt-2 text-base font-semibold text-font-main">
+              {getConsecutiveStatusLabel(snapshot)}
+            </p>
+          </div>
+        </div>
+
+        <div className="border-t border-gray-100 pt-5">
+          <p className="text-sm font-medium text-gray-400">카테고리 요약</p>
+          <div className="mt-4 grid grid-cols-2 gap-x-6 gap-y-3">
+            {categories.map((category) => (
+              <div key={category.key} className="flex items-center justify-between gap-3">
+                <span className="text-xs font-medium text-font-main">{category.label}</span>
+                <span className="text-xs font-semibold text-font-main">{category.value}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="rounded-control border border-dashed border-primary-200 bg-primary-50/30 px-4 py-4">
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-xs font-medium text-font-sub">인증 코드</span>
+            <span className="text-xs font-semibold text-font-main">
+              {certificate.verificationCode}
+            </span>
+          </div>
+          <div className="mt-3 flex items-start justify-between gap-3">
+            <span className="text-xs font-medium text-font-sub">검증 URL</span>
+            <span className="max-w-[220px] break-all text-right text-xs font-medium text-font-main">
+              {certificate.verificationUrl}
+            </span>
+          </div>
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+export function ReportVerificationPage() {
+  const navigate = useNavigate()
+  const { token } = useParams<{ token: string }>()
+  const [isLoading, setIsLoading] = useState(true)
+  const [isFetchError, setIsFetchError] = useState(false)
+  const [verificationStatus, setVerificationStatus] = useState<ReportVerificationStatus>('INVALID')
+  const [certificate, setCertificate] = useState<ReportCertificateMeta | null>(null)
+  const [snapshot, setSnapshot] = useState<ReportCertificateSnapshot | null>(null)
+  const [reloadCount, setReloadCount] = useState(0)
+
+  useEffect(() => {
+    let cancelled = false
+
+    const fetchVerification = async () => {
+      if (!token) {
+        setVerificationStatus('INVALID')
+        setCertificate(null)
+        setSnapshot(null)
+        setIsLoading(false)
+        return
+      }
+
+      setIsLoading(true)
+      setIsFetchError(false)
+
+      try {
+        const response = await verifyReport(token)
+
+        if (cancelled) {
+          return
+        }
+
+        setVerificationStatus(response.verificationStatus)
+        setCertificate(response.certificate)
+        setSnapshot(response.snapshot)
+      } catch {
+        if (!cancelled) {
+          setIsFetchError(true)
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    fetchVerification()
+
+    return () => {
+      cancelled = true
+    }
+  }, [reloadCount, token])
+
+  const statusTone = useMemo(() => getStatusTone(verificationStatus), [verificationStatus])
+
+  return (
+    <div className="app-shell flex items-center justify-center !pb-10">
+      <div className="w-full space-y-4">
+        {isLoading ? <VerificationSkeleton /> : null}
+
+        {!isLoading && isFetchError ? (
+          <Card className="!gap-0 !border border-gray-200 !bg-white !p-0 shadow-[0_18px_45px_rgba(15,23,42,0.08)]">
+            <div className="space-y-4 px-6 py-10 text-center">
+              <h1 className="text-xl font-semibold text-font-main">인증서 정보를 불러오지 못했습니다</h1>
+              <p className="text-sm leading-relaxed text-font-sub">
+                잠시 후 다시 시도해 주세요.
+              </p>
+              <div className="flex justify-center gap-2 pt-2">
+                <Button variant="sub" size="sm" onClick={() => setReloadCount((value) => value + 1)}>
+                  다시 시도
+                </Button>
+                <Button variant="outline" size="sm" onClick={() => navigate(ROUTE_PATHS.root)}>
+                  SOLVE로 이동
+                </Button>
+              </div>
+            </div>
+          </Card>
+        ) : null}
+
+        {!isLoading && !isFetchError ? (
+          <>
+            <Card className="!gap-0 !border border-gray-200 !bg-white !p-0 shadow-[0_12px_30px_rgba(15,23,42,0.06)]">
+              <div className="space-y-3 px-6 py-6 text-center">
+                <div className="flex justify-center">
+                  <span
+                    className={[
+                      'inline-flex rounded-full px-3 py-1 text-xs font-semibold',
+                      statusTone.badgeClassName,
+                    ].join(' ')}
+                  >
+                    {verificationStatus === 'ACTIVE'
+                      ? '유효'
+                      : verificationStatus === 'REVOKED'
+                        ? '폐기'
+                        : '무효'}
+                  </span>
+                </div>
+                <h1 className="text-2xl font-semibold tracking-tight text-font-main">
+                  {statusTone.title}
+                </h1>
+                <p className="text-sm leading-relaxed text-font-sub">{statusTone.description}</p>
+              </div>
+            </Card>
+
+            {verificationStatus === 'ACTIVE' && certificate && snapshot ? (
+              <VerificationSummary certificate={certificate} snapshot={snapshot} />
+            ) : verificationStatus === 'REVOKED' && certificate ? (
+              <Card className="!gap-0 !border border-gray-200 !bg-white !p-0 shadow-[0_18px_45px_rgba(15,23,42,0.08)]">
+                <div className="space-y-4 px-6 py-7">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-sm font-medium text-font-sub">인증서 번호</span>
+                    <span className="text-sm font-semibold text-font-main">
+                      {certificate.certificateNumber}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-sm font-medium text-font-sub">발급일</span>
+                    <span className="text-sm font-semibold text-font-main">
+                      {formatDisplayDate(certificate.issuedAt)}
+                    </span>
+                  </div>
+                  <div className="rounded-control border border-amber-100 bg-amber-50 px-4 py-4 text-sm leading-relaxed text-amber-700">
+                    해당 인증서는 발급 후 상태가 변경되어 더 이상 사용할 수 없습니다.
+                  </div>
+                </div>
+              </Card>
+            ) : (
+              <Card className="!gap-0 !border border-gray-200 !bg-white !p-0 shadow-[0_18px_45px_rgba(15,23,42,0.08)]">
+                <div className="space-y-4 px-6 py-7">
+                  <div className="rounded-control border border-red-100 bg-red-50 px-4 py-4 text-sm leading-relaxed text-red-600">
+                    인증서 번호 또는 검증 토큰이 올바르지 않습니다. 발급받은 URL을 다시 확인해 주세요.
+                  </div>
+                </div>
+              </Card>
+            )}
+          </>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -46,6 +46,7 @@ import { MyReportPage } from '../pages/my/MyReportPage'
 import { MySavingsHistoryPage } from '../pages/my/MySavingsHistoryPage'
 import { MyPage } from '../pages/my/MyPage'
 import { NotFoundPage } from '../pages/NotFoundPage'
+import { ReportVerificationPage } from '../pages/report/ReportVerificationPage'
 import { RecommendPage } from '../pages/recommend/RecommendPage'
 import { EnvironmentEntryModalRoute } from '../pages/esg/env/EnvironmentEntryModalRoute'
 import { EnvironmentEntryPage } from '../pages/esg/env/EnvironmentEntryPage'
@@ -79,6 +80,8 @@ function AppRoutes() {
           <Route path={ROUTE_PATHS.signup} element={<SignupPage />} />
           <Route path={ROUTE_PATHS.signupComplete} element={<SignupCompletePage />} />
         </Route>
+
+        <Route path={ROUTE_PATHS.reportVerify} element={<ReportVerificationPage />} />
 
         <Route element={<ProtectedRoute />}>
           <Route path={ROUTE_PATHS.onboarding} element={<OnboardingPage />} />

--- a/src/services/reportService.ts
+++ b/src/services/reportService.ts
@@ -1,0 +1,39 @@
+import { apiClient } from './apiClient'
+import type {
+  ReportIssueResponse,
+  ReportPeriodType,
+  ReportPreviewResponse,
+  ReportVerificationResponse,
+} from '../types/report'
+
+interface GetReportPreviewParams {
+  periodType: ReportPeriodType
+}
+
+export const getReportPreview = async (
+  params: GetReportPreviewParams,
+): Promise<ReportPreviewResponse> => {
+  const response = await apiClient.get<ReportPreviewResponse>('/my/reports/preview', {
+    params,
+  })
+  return response.data
+}
+
+export const issueReport = async (periodType: ReportPeriodType): Promise<ReportIssueResponse> => {
+  const response = await apiClient.post<ReportIssueResponse>('/my/reports/issues', {
+    periodType,
+  })
+  return response.data
+}
+
+export const downloadReportPdf = async (issueId: number): Promise<Blob> => {
+  const response = await apiClient.get<Blob>(`/my/reports/issues/${issueId}/pdf`, {
+    responseType: 'blob',
+  })
+  return response.data
+}
+
+export const verifyReport = async (token: string): Promise<ReportVerificationResponse> => {
+  const response = await apiClient.get<ReportVerificationResponse>(`/reports/verify/${token}`)
+  return response.data
+}

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -1,0 +1,51 @@
+import type { UserGrade } from './user'
+
+export type ReportPeriodType = '3M' | '6M' | '1Y'
+
+export interface ReportCategorySummary {
+  categoryKey: string
+  label: string
+  value: number
+  unit: string
+}
+
+export interface ReportCertificateSnapshot {
+  recipientName: string
+  periodType: ReportPeriodType
+  periodLabel: string
+  referenceDate: string
+  targetStartDate: string
+  targetEndDate: string
+  currentGrade: UserGrade
+  totalScore: number
+  verifiedActivityCount: number
+  consecutiveMaxAchievementMonths: number
+  showConsecutiveAchievementBadge: boolean
+  categories: ReportCategorySummary[]
+}
+
+export interface ReportPreviewResponse {
+  snapshot: ReportCertificateSnapshot
+}
+
+export interface ReportCertificateMeta {
+  issueId: number
+  certificateNumber: string
+  verificationCode: string
+  verificationUrl: string
+  issuedAt: string
+}
+
+export interface ReportIssueResponse {
+  certificate: ReportCertificateMeta
+  snapshot: ReportCertificateSnapshot
+}
+
+export type ReportVerificationStatus = 'ACTIVE' | 'REVOKED' | 'INVALID'
+
+export interface ReportVerificationResponse {
+  valid: boolean
+  verificationStatus: ReportVerificationStatus
+  certificate: ReportCertificateMeta | null
+  snapshot: ReportCertificateSnapshot | null
+}


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이슈 번호를 적어주세요. 머지 시 자동으로 이슈가 닫힙니다. -->
Closes #66

## 📌 작업 내용
<!-- 어떤 작업을 했는지 간단히 설명 -->
- 마이페이지 ESG 활동 현황 및 인증서 화면 구현
- ESG 활동 인증서 발급/검증 화면 연동 및 포인트 내역 UI 보완

## 🛠 변경 사항
<!-- 주요 변경 파일이나 로직을 설명 -->
- MyPage 메뉴 구조 정리 및 활동 관련 메뉴 흐름 개선
- MyReportPage에서 ESG 활동 인증서 화면 구현 및 기간별 미리보기/발급 API 연동
- 인증서 발급 후 PDF 다운로드 흐름 연동 및 인증서 화면 워터마크 반영
- reportService, report 타입 추가 및 인증서 preview/issue/verify API 연동
- ReportVerificationPage 추가 및 /report/verify/:token 공개 라우트 연결
- 인증서 검증 결과에 따라 유효/무효/폐기 상태 분기 화면 구현
- MyPointManagePage 상단 포인트 요약 카드에 S3 이미지 표시 UI 추가

## ✅ 테스트 결과
<!-- 테스트를 어떻게 했는지 (로컬 실행, API 테스트 등) -->
- [x] 로컬에서 정상 동작 확인
- [x] API 테스트 완료 (해당되면)
- [x] 빌드 에러 없음

## 📸 스크린샷
<!-- UI 변경이 있으면 스크린샷 첨부 -->

## 💡 리뷰어에게
<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분 -->
