### PR TITLE
[FEAT] 79 봉사 신청 목록 조회 페이지 구현

### DIFF
--- a/src/constants/routePaths.ts
+++ b/src/constants/routePaths.ts
@@ -21,6 +21,7 @@ export const ROUTE_PATHS = {
   activitySocialDonation: '/esg/social/donation',
   activitySocialStore: '/esg/social/store',
   activitySocialVolunteer: '/esg/social/volunteer',
+  activitySocialVolunteerApplications: '/esg/social/volunteers/applications',
   activitySocialVolunteerAttendance: '/esg/social/volunteers/attendance',
   activitySocialVolunteerAttendanceComplete:
     '/esg/social/volunteers/attendance/complete',

--- a/src/pages/esg/social/VolunteerApplicationsPage.tsx
+++ b/src/pages/esg/social/VolunteerApplicationsPage.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { IconButton, Icons, Card } from '../../../components/common'
+import BottomNavigation from '../../../components/layout/BottomNavigation'
+import Header from '../../../components/layout/Header'
+import MainLayout from '../../../components/layout/MainLayout'
+import {
+  getVolunteerDetailPath,
+  ROUTE_PATHS,
+} from '../../../constants/routePaths'
+import { getVolunteerApplications } from '../../../services/volunteerService'
+import type { VolunteerListResponse } from '../../../types/volunteer'
+import { VolunteerActivityCard } from './components/VolunteerActivityCard'
+
+export function VolunteerApplicationsPage() {
+  const navigate = useNavigate()
+  const [volunteerData, setVolunteerData] =
+    useState<VolunteerListResponse | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let isMounted = true
+
+    const fetchVolunteerApplications = async () => {
+      setIsLoading(true)
+      setError('')
+
+      try {
+        const response = await getVolunteerApplications()
+        if (!isMounted) {
+          return
+        }
+        setVolunteerData(response)
+      } catch (fetchError) {
+        console.error(fetchError)
+        if (!isMounted) {
+          return
+        }
+        setError(
+          '신청한 봉사활동을 불러오지 못했어요. 잠시 후 다시 시도해주세요.',
+        )
+      }
+
+      if (isMounted) {
+        setIsLoading(false)
+      }
+    }
+
+    void fetchVolunteerApplications()
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  const handleBottomNavigation = (key: string) => {
+    if (key === 'home') {
+      navigate(ROUTE_PATHS.home)
+      return
+    }
+
+    if (key === 'benefits') {
+      navigate(ROUTE_PATHS.shop)
+      return
+    }
+
+    if (key === 'finance') {
+      navigate(ROUTE_PATHS.finance)
+      return
+    }
+
+    if (key === 'mypage') {
+      navigate(ROUTE_PATHS.my)
+    }
+  }
+
+  return (
+    <MainLayout
+      header={
+        <Header
+          left={
+            <IconButton
+              label="뒤로가기"
+              icon={<Icons.Back className="text-font-main" />}
+              onClick={() => navigate(-1)}
+            />
+          }
+          title="봉사"
+        />
+      }
+      nav={<BottomNavigation value="home" onChange={handleBottomNavigation} />}
+    >
+      {isLoading ? (
+        <section className="space-y-3 pt-2">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <Card
+              key={index}
+              className="rounded-control !p-4 shadow-[0_2px_8px_rgba(0,0,0,0.05)]"
+            >
+              <div className="space-y-3">
+                <div className="h-3 w-24 animate-pulse rounded-full bg-gray-200" />
+                <div className="h-5 w-2/3 animate-pulse rounded-full bg-gray-300" />
+                <div className="h-4 w-full animate-pulse rounded-full bg-gray-200" />
+                <div className="h-4 w-4/5 animate-pulse rounded-full bg-gray-200" />
+              </div>
+            </Card>
+          ))}
+        </section>
+      ) : null}
+
+      {!isLoading && error ? (
+        <section className="pt-2">
+          <Card className="rounded-card border border-red-100 bg-red-50 px-5 py-6 text-center shadow-card">
+            <h2 className="text-lg font-semibold text-font-main">
+              봉사 신청 목록을 불러오지 못했어요
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-font-sub">{error}</p>
+          </Card>
+        </section>
+      ) : null}
+
+      {!isLoading && !error && volunteerData ? (
+        <section className="mx-[-16px] min-h-[calc(100vh-var(--header-h)-var(--nav-h)-48px)] bg-gray-100 px-4 pt-4">
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <h2 className="text-[18px] leading-[120%] font-semibold tracking-[-0.02em] text-font-main">
+                신청한 봉사활동
+              </h2>
+              <span className="text-sm leading-[120%] font-medium tracking-[-0.02em] text-primary-400">
+                {volunteerData.volunteers.length}건
+              </span>
+            </div>
+
+            {volunteerData.volunteers.length > 0 ? (
+              <div className="space-y-4">
+                {volunteerData.volunteers.map((volunteer) => (
+                  <VolunteerActivityCard
+                    key={volunteer.volunteerId}
+                    volunteer={volunteer}
+                    actionLabel="신청 취소"
+                    onClick={() =>
+                      navigate(getVolunteerDetailPath(volunteer.volunteerId))
+                    }
+                  />
+                ))}
+              </div>
+            ) : (
+              <Card className="rounded-control !p-6 text-center shadow-[0_2px_8px_rgba(0,0,0,0.05)]">
+                <p className="text-sm leading-6 font-medium text-font-sub">
+                  아직 신청한 봉사활동이 없습니다.
+                </p>
+              </Card>
+            )}
+
+            <p className="px-1 pb-6 text-sm leading-6 font-medium text-gray-400">
+              봉사 시작 24시간 전까지만 취소할 수 있으며, 신청한 봉사에
+              미참석하거나 활동 시간을 채우지 못할 경우 계정 이용 제한 및
+              패널티가 발생할 수 있습니다.
+            </p>
+          </div>
+        </section>
+      ) : null}
+    </MainLayout>
+  )
+}

--- a/src/pages/esg/social/VolunteerApplicationsPage.tsx
+++ b/src/pages/esg/social/VolunteerApplicationsPage.tsx
@@ -172,7 +172,7 @@ export function VolunteerApplicationsPage() {
             <IconButton
               label="뒤로가기"
               icon={<Icons.Back className="text-font-main" />}
-              onClick={() => navigate(-1)}
+              onClick={() => navigate(ROUTE_PATHS.activitySocialVolunteer)}
             />
           }
           title="봉사"

--- a/src/pages/esg/social/VolunteerApplicationsPage.tsx
+++ b/src/pages/esg/social/VolunteerApplicationsPage.tsx
@@ -1,6 +1,7 @@
+import axios from 'axios'
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { IconButton, Icons, Card } from '../../../components/common'
+import { Button, Card, IconButton, Icons } from '../../../components/common'
 import BottomNavigation from '../../../components/layout/BottomNavigation'
 import Header from '../../../components/layout/Header'
 import MainLayout from '../../../components/layout/MainLayout'
@@ -8,16 +9,27 @@ import {
   getVolunteerDetailPath,
   ROUTE_PATHS,
 } from '../../../constants/routePaths'
-import { getVolunteerApplications } from '../../../services/volunteerService'
-import type { VolunteerListResponse } from '../../../types/volunteer'
+import {
+  cancelVolunteerApplication,
+  getVolunteerApplications,
+} from '../../../services/volunteerService'
+import type {
+  VolunteerApplicationItem,
+  VolunteerApplicationListResponse,
+} from '../../../types/volunteer'
 import { VolunteerActivityCard } from './components/VolunteerActivityCard'
 
 export function VolunteerApplicationsPage() {
   const navigate = useNavigate()
   const [volunteerData, setVolunteerData] =
-    useState<VolunteerListResponse | null>(null)
+    useState<VolunteerApplicationListResponse | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState('')
+  const [actionMessage, setActionMessage] = useState('')
+  const [cancelError, setCancelError] = useState('')
+  const [selectedApplication, setSelectedApplication] =
+    useState<VolunteerApplicationItem | null>(null)
+  const [isCancelling, setIsCancelling] = useState(false)
 
   useEffect(() => {
     let isMounted = true
@@ -54,6 +66,20 @@ export function VolunteerApplicationsPage() {
     }
   }, [])
 
+  useEffect(() => {
+    if (!actionMessage) {
+      return
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setActionMessage('')
+    }, 2200)
+
+    return () => {
+      window.clearTimeout(timeoutId)
+    }
+  }, [actionMessage])
+
   const handleBottomNavigation = (key: string) => {
     if (key === 'home') {
       navigate(ROUTE_PATHS.home)
@@ -72,6 +98,69 @@ export function VolunteerApplicationsPage() {
 
     if (key === 'mypage') {
       navigate(ROUTE_PATHS.my)
+    }
+  }
+
+  const getCancelErrorMessage = (cancelActionError: unknown) => {
+    if (axios.isAxiosError(cancelActionError)) {
+      const responseMessage =
+        typeof cancelActionError.response?.data?.message === 'string'
+          ? cancelActionError.response.data.message.trim()
+          : ''
+
+      if (responseMessage) {
+        return responseMessage
+      }
+    }
+
+    return '봉사 신청 취소에 실패했어요. 잠시 후 다시 시도해주세요.'
+  }
+
+  const handleOpenCancelModal = (volunteer: VolunteerApplicationItem) => {
+    setActionMessage('')
+    setCancelError('')
+    setSelectedApplication(volunteer)
+  }
+
+  const handleCloseCancelModal = () => {
+    if (isCancelling) {
+      return
+    }
+
+    setSelectedApplication(null)
+  }
+
+  const handleCancelVolunteerApplication = async () => {
+    if (!selectedApplication) {
+      return
+    }
+
+    setIsCancelling(true)
+    setCancelError('')
+
+    try {
+      await cancelVolunteerApplication(selectedApplication.volunteerApplicationId)
+
+      setVolunteerData((prev) => {
+        if (!prev) {
+          return prev
+        }
+
+        return {
+          volunteers: prev.volunteers.filter(
+            (volunteer) =>
+              volunteer.volunteerApplicationId !==
+              selectedApplication.volunteerApplicationId,
+          ),
+        }
+      })
+      setActionMessage('봉사 신청이 취소되었어요.')
+      setSelectedApplication(null)
+    } catch (cancelActionError) {
+      console.error(cancelActionError)
+      setCancelError(getCancelErrorMessage(cancelActionError))
+    } finally {
+      setIsCancelling(false)
     }
   }
 
@@ -139,6 +228,7 @@ export function VolunteerApplicationsPage() {
                     key={volunteer.volunteerId}
                     volunteer={volunteer}
                     actionLabel="신청 취소"
+                    onActionClick={() => handleOpenCancelModal(volunteer)}
                     onClick={() =>
                       navigate(getVolunteerDetailPath(volunteer.volunteerId))
                     }
@@ -160,6 +250,68 @@ export function VolunteerApplicationsPage() {
             </p>
           </div>
         </section>
+      ) : null}
+
+      {selectedApplication ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/35 px-4"
+          onClick={handleCloseCancelModal}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="volunteer-cancel-modal-title"
+            className="w-full max-w-[340px] rounded-[8px] bg-white px-5 pt-6 pb-5 shadow-[0_8px_24px_rgba(15,23,42,0.16)]"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="text-center">
+              <h2
+                id="volunteer-cancel-modal-title"
+                className="text-center text-lg font-semibold text-font-main"
+              >
+                신청을 취소하시겠습니까?
+              </h2>
+              <p className="mt-2 text-center text-sm leading-6 text-gray-400">
+                봉사 시작 24시간 전까지만 취소할 수 있으며,
+                <br />
+                이후에는 신청 취소가 제한될 수 있습니다.
+              </p>
+              {cancelError ? (
+                <p className="mt-3 text-center text-sm leading-6 text-red-500">
+                  {cancelError}
+                </p>
+              ) : null}
+            </div>
+
+            <div className="mt-5 flex gap-3">
+              <Button
+                variant="gray"
+                fullWidth
+                className="!rounded-[8px]"
+                onClick={handleCloseCancelModal}
+                disabled={isCancelling}
+              >
+                아니요
+              </Button>
+              <Button
+                fullWidth
+                className="!rounded-[8px]"
+                onClick={() => void handleCancelVolunteerApplication()}
+                disabled={isCancelling}
+              >
+                {isCancelling ? '취소 중...' : '네'}
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {actionMessage ? (
+        <div className="pointer-events-none fixed inset-x-0 bottom-[calc(var(--nav-h)+20px)] z-50 flex justify-center px-4">
+          <div className="rounded-full bg-primary-400 px-4 py-2 text-sm font-medium text-white shadow-lg">
+            {actionMessage}
+          </div>
+        </div>
       ) : null}
     </MainLayout>
   )

--- a/src/pages/esg/social/VolunteerCompletePage.tsx
+++ b/src/pages/esg/social/VolunteerCompletePage.tsx
@@ -90,7 +90,17 @@ export function VolunteerCompletePage() {
                 </div>
               </div>
 
-              <div className="mt-5 w-full">
+              <div className="mt-5 grid w-full grid-cols-2 gap-3">
+                <Button
+                  fullWidth
+                  size="md"
+                  variant="sub"
+                  onClick={() =>
+                    navigate(ROUTE_PATHS.activitySocialVolunteerApplications)
+                  }
+                >
+                  신청 목록으로 가기
+                </Button>
                 <Button
                   fullWidth
                   size="md"
@@ -123,7 +133,16 @@ export function VolunteerCompletePage() {
                 </Button>
               </div>
             </div>
-            <div className="mt-6 w-full">
+            <div className="mt-6 grid w-full grid-cols-2 gap-3">
+              <Button
+                fullWidth
+                variant="sub"
+                onClick={() =>
+                  navigate(ROUTE_PATHS.activitySocialVolunteerApplications)
+                }
+              >
+                신청 목록으로 가기
+              </Button>
               <Button
                 fullWidth
                 variant="primary"

--- a/src/pages/esg/social/VolunteerDetailPage.tsx
+++ b/src/pages/esg/social/VolunteerDetailPage.tsx
@@ -141,7 +141,7 @@ export function VolunteerDetailPage() {
             <IconButton
               label="뒤로가기"
               icon={<Icons.Back className="text-font-main" />}
-              onClick={() => navigate(ROUTE_PATHS.activitySocialVolunteer)}
+              onClick={() => navigate(-1)}
             />
           }
           title="봉사"

--- a/src/pages/esg/social/VolunteerDetailPage.tsx
+++ b/src/pages/esg/social/VolunteerDetailPage.tsx
@@ -4,10 +4,7 @@ import { BottomActionBar, Button, IconButton } from '../../../components/common'
 import { Icons } from '../../../components/common'
 import Header from '../../../components/layout/Header'
 import MainLayout from '../../../components/layout/MainLayout'
-import {
-  getVolunteerCompletePath,
-  ROUTE_PATHS,
-} from '../../../constants/routePaths'
+import { getVolunteerCompletePath } from '../../../constants/routePaths'
 import {
   applyVolunteer,
   getVolunteerDetail,

--- a/src/pages/esg/social/VolunteerPage.tsx
+++ b/src/pages/esg/social/VolunteerPage.tsx
@@ -10,53 +10,9 @@ import {
   ROUTE_PATHS,
 } from '../../../constants/routePaths'
 import { getVolunteerActivities } from '../../../services/volunteerService'
-import type { VolunteerActivity, VolunteerListResponse } from '../../../types/volunteer'
+import type { VolunteerListResponse } from '../../../types/volunteer'
+import { VolunteerActivityCard } from './components/VolunteerActivityCard'
 import { SocialActivityTabs } from './components/SocialActivityTabs'
-
-const formatVolunteerDate = (activityDate: string) => {
-  const date = new Date(activityDate)
-
-  if (Number.isNaN(date.getTime())) {
-    return activityDate
-  }
-
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-
-  return `${year}.${month}.${day}`
-}
-
-const formatVolunteerTimeRange = (
-  activityDate: string,
-  volunteerHour: number,
-) => {
-  const startDate = new Date(activityDate)
-
-  if (Number.isNaN(startDate.getTime())) {
-    return `${volunteerHour}시간`
-  }
-
-  const endDate = new Date(startDate)
-  endDate.setHours(endDate.getHours() + volunteerHour)
-
-  const formatTime = (date: Date) =>
-    `${String(date.getHours()).padStart(2, '0')}:${String(
-      date.getMinutes(),
-    ).padStart(2, '0')}`
-
-  return `${formatTime(startDate)} - ${formatTime(endDate)}`
-}
-
-const formatVolunteerLocation = (location: string) =>
-  location
-    .trim()
-    .split(/\s+/)
-    .slice(0, 2)
-    .join(' ')
-
-const getVolunteerMetaLabel = (volunteer: VolunteerActivity) =>
-  `${volunteer.organization} | ${formatVolunteerLocation(volunteer.location)}`
 
 export function VolunteerPage() {
   const navigate = useNavigate()
@@ -182,48 +138,13 @@ export function VolunteerPage() {
 
             <div className="space-y-4">
               {volunteerData.volunteers.map((volunteer) => (
-                <Card
+                <VolunteerActivityCard
                   key={volunteer.volunteerId}
-                  data-volunteer-id={volunteer.volunteerId}
-                  className="rounded-control !p-5 shadow-[0_2px_8px_rgba(0,0,0,0.05)]"
+                  volunteer={volunteer}
                   onClick={() =>
                     navigate(getVolunteerDetailPath(volunteer.volunteerId))
                   }
-                >
-                  <div className="flex flex-col gap-3">
-                    <div className="flex flex-col gap-1">
-                      <p className="text-sm leading-[120%] font-medium tracking-[-0.02em] text-font-sub">
-                        {getVolunteerMetaLabel(volunteer)}
-                      </p>
-                      <h3 className="text-[18px] leading-[120%] font-bold tracking-[-0.02em] text-font-main">
-                        {volunteer.name}
-                      </h3>
-                    </div>
-
-                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-                      <div className="flex items-center gap-1">
-                        <span className="text-xs leading-[120%] font-medium tracking-[-0.02em] text-primary-400">
-                          봉사날짜
-                        </span>
-                        <span className="text-xs leading-[120%] font-normal tracking-[-0.02em] text-font-sub">
-                          {formatVolunteerDate(volunteer.activityDate)}
-                        </span>
-                      </div>
-
-                      <div className="flex items-center gap-1">
-                        <span className="text-xs leading-[120%] font-medium tracking-[-0.02em] text-primary-400">
-                          봉사시간
-                        </span>
-                        <span className="text-xs leading-[120%] font-normal tracking-[-0.02em] text-font-sub">
-                          {formatVolunteerTimeRange(
-                            volunteer.activityDate,
-                            volunteer.volunteerHour,
-                          )}
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                </Card>
+                />
               ))}
             </div>
           </div>

--- a/src/pages/esg/social/VolunteerPage.tsx
+++ b/src/pages/esg/social/VolunteerPage.tsx
@@ -131,9 +131,15 @@ export function VolunteerPage() {
               <h2 className="text-[18px] leading-[120%] font-semibold tracking-[-0.02em] text-font-main">
                 모집중인 봉사활동
               </h2>
-              <span className="text-sm leading-[120%] font-medium tracking-[-0.02em] text-primary-400">
-                {volunteerData.volunteers.length}건
-              </span>
+              <button
+                type="button"
+                className="text-sm leading-[120%] font-medium tracking-[-0.02em] text-primary-400"
+                onClick={() =>
+                  navigate(ROUTE_PATHS.activitySocialVolunteerApplications)
+                }
+              >
+                신청한 봉사
+              </button>
             </div>
 
             <div className="space-y-4">

--- a/src/pages/esg/social/components/VolunteerActivityCard.tsx
+++ b/src/pages/esg/social/components/VolunteerActivityCard.tsx
@@ -1,0 +1,118 @@
+import { Card } from '../../../../components/common'
+import type { VolunteerActivity } from '../../../../types/volunteer'
+
+const formatVolunteerDate = (activityDate: string) => {
+  const date = new Date(activityDate)
+
+  if (Number.isNaN(date.getTime())) {
+    return activityDate
+  }
+
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+
+  return `${year}.${month}.${day}`
+}
+
+const formatVolunteerTimeRange = (
+  activityDate: string,
+  volunteerHour: number,
+) => {
+  const startDate = new Date(activityDate)
+
+  if (Number.isNaN(startDate.getTime())) {
+    return `${volunteerHour}시간`
+  }
+
+  const endDate = new Date(startDate)
+  endDate.setHours(endDate.getHours() + volunteerHour)
+
+  const formatTime = (date: Date) =>
+    `${String(date.getHours()).padStart(2, '0')}:${String(
+      date.getMinutes(),
+    ).padStart(2, '0')}`
+
+  return `${formatTime(startDate)} - ${formatTime(endDate)}`
+}
+
+const formatVolunteerLocation = (location: string) =>
+  location
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .join(' ')
+
+const getVolunteerMetaLabel = (volunteer: VolunteerActivity) =>
+  `${volunteer.organization} | ${formatVolunteerLocation(volunteer.location)}`
+
+interface VolunteerActivityCardProps {
+  volunteer: VolunteerActivity
+  onClick?: () => void
+  actionLabel?: string
+  onActionClick?: () => void
+}
+
+export const VolunteerActivityCard = ({
+  volunteer,
+  onClick,
+  actionLabel,
+  onActionClick,
+}: VolunteerActivityCardProps) => {
+  return (
+    <Card
+      data-volunteer-id={volunteer.volunteerId}
+      className="rounded-control !p-5 shadow-[0_2px_8px_rgba(0,0,0,0.05)]"
+      onClick={onClick}
+    >
+      <div className="flex items-stretch justify-between gap-4">
+        <div className="flex flex-1 flex-col gap-3">
+          <div className="flex flex-col gap-1">
+            <p className="text-sm leading-[120%] font-medium tracking-[-0.02em] text-font-sub">
+              {getVolunteerMetaLabel(volunteer)}
+            </p>
+            <h3 className="text-[18px] leading-[120%] font-bold tracking-[-0.02em] text-font-main">
+              {volunteer.name}
+            </h3>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            <div className="flex items-center gap-1">
+              <span className="text-xs leading-[120%] font-medium tracking-[-0.02em] text-primary-400">
+                봉사날짜
+              </span>
+              <span className="text-xs leading-[120%] font-normal tracking-[-0.02em] text-font-sub">
+                {formatVolunteerDate(volunteer.activityDate)}
+              </span>
+            </div>
+
+            <div className="flex items-center gap-1">
+              <span className="text-xs leading-[120%] font-medium tracking-[-0.02em] text-primary-400">
+                봉사시간
+              </span>
+              <span className="text-xs leading-[120%] font-normal tracking-[-0.02em] text-font-sub">
+                {formatVolunteerTimeRange(
+                  volunteer.activityDate,
+                  volunteer.volunteerHour,
+                )}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {actionLabel ? (
+          <button
+            type="button"
+            className="flex shrink-0 items-center self-stretch text-sm leading-[120%] font-medium tracking-[-0.02em] text-primary-400"
+            onClick={(event) => {
+              event.stopPropagation()
+              onActionClick?.()
+            }}
+          >
+            {actionLabel}
+          </button>
+        ) : null}
+      </div>
+    </Card>
+  )
+}

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -23,6 +23,7 @@ import { ValueStorePaymentPage } from '../pages/esg/social/ValueStorePaymentPage
 import { ValueStorePaymentRedirectPage } from '../pages/esg/social/ValueStorePaymentRedirectPage'
 import { ValueStorePage } from '../pages/esg/social/ValueStorePage'
 import { VolunteerCompletePage } from '../pages/esg/social/VolunteerCompletePage'
+import { VolunteerApplicationsPage } from '../pages/esg/social/VolunteerApplicationsPage'
 import { VolunteerDetailPage } from '../pages/esg/social/VolunteerDetailPage'
 import { VolunteerPage } from '../pages/esg/social/VolunteerPage'
 
@@ -118,6 +119,10 @@ function AppRoutes() {
             <Route
               path={ROUTE_PATHS.activitySocialVolunteer}
               element={<VolunteerPage />}
+            />
+            <Route
+              path={ROUTE_PATHS.activitySocialVolunteerApplications}
+              element={<VolunteerApplicationsPage />}
             />
             <Route
               path={ROUTE_PATHS.activitySocialVolunteerDetail}

--- a/src/services/volunteerService.ts
+++ b/src/services/volunteerService.ts
@@ -16,6 +16,13 @@ export const getVolunteerActivities = async (): Promise<VolunteerListResponse> =
   return response.data
 }
 
+export const getVolunteerApplications = async (): Promise<VolunteerListResponse> => {
+  const response = await apiClient.get<VolunteerListResponse>(
+    '/v1/esg/s/volunteers/applications',
+  )
+  return response.data
+}
+
 export const getVolunteerDetail = async (
   volunteerId: number,
 ): Promise<VolunteerDetail> => {

--- a/src/services/volunteerService.ts
+++ b/src/services/volunteerService.ts
@@ -1,6 +1,8 @@
 import { apiClient } from './apiClient'
 import type {
   ApplyVolunteerRequest,
+  VolunteerApplicationItem,
+  VolunteerApplicationListResponse,
   VolunteerApplicationResponse,
   VolunteerAttendanceInfo,
   VolunteerCheckInRequest,
@@ -8,7 +10,6 @@ import type {
   VolunteerCheckOutRequest,
   VolunteerCheckOutResponse,
   VolunteerDetail,
-  VolunteerListResponse,
 } from '../types/volunteer'
 
 export const getVolunteerActivities = async (): Promise<VolunteerListResponse> => {
@@ -16,11 +17,19 @@ export const getVolunteerActivities = async (): Promise<VolunteerListResponse> =
   return response.data
 }
 
-export const getVolunteerApplications = async (): Promise<VolunteerListResponse> => {
-  const response = await apiClient.get<VolunteerListResponse>(
+export const getVolunteerApplications = async (): Promise<VolunteerApplicationListResponse> => {
+  const response = await apiClient.get<VolunteerApplicationListResponse>(
     '/v1/esg/s/volunteers/applications',
   )
   return response.data
+}
+
+export const cancelVolunteerApplication = async (
+  volunteerApplicationId: VolunteerApplicationItem['volunteerApplicationId'],
+): Promise<void> => {
+  await apiClient.delete(
+    `/v1/esg/s/volunteers/applications/${volunteerApplicationId}`,
+  )
 }
 
 export const getVolunteerDetail = async (

--- a/src/services/volunteerService.ts
+++ b/src/services/volunteerService.ts
@@ -10,6 +10,7 @@ import type {
   VolunteerCheckOutRequest,
   VolunteerCheckOutResponse,
   VolunteerDetail,
+  VolunteerListResponse,
 } from '../types/volunteer'
 
 export const getVolunteerActivities = async (): Promise<VolunteerListResponse> => {

--- a/src/types/volunteer.ts
+++ b/src/types/volunteer.ts
@@ -17,6 +17,14 @@ export interface VolunteerListResponse {
   volunteers: VolunteerActivity[]
 }
 
+export interface VolunteerApplicationItem extends VolunteerActivity {
+  volunteerApplicationId: number
+}
+
+export interface VolunteerApplicationListResponse {
+  volunteers: VolunteerApplicationItem[]
+}
+
 export interface ApplyVolunteerRequest {
   volunteerId: number
 }


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이슈 번호를 적어주세요. 머지 시 자동으로 이슈가 닫힙니다. -->
Closes #79 

## 📌 작업 내용
<!-- 어떤 작업을 했는지 간단히 설명 -->
- 봉사 신청 목록 페이지를 추가하고 로그인 사용자가 신청한 봉사활동을 조회할 수 있도록 구현했습니다.
- 봉사 신청 목록에서 신청 취소 기능을 연동하고, 확인 모달과 성공 안내 흐름을 추가했습니다.
- 봉사 신청 완료 페이지와 신청 목록 사이의 이동 흐름을 정리했습니다.


## 🛠 변경 사항
<!-- 주요 변경 파일이나 로직을 설명 -->
- src/pages/esg/social/VolunteerApplicationsPage.tsx 에 봉사 신청 목록 페이지를 추가하고 신청 목록 조회 API를 연동했습니다.
- src/pages/esg/social/components/VolunteerActivityCard.tsx 로 봉사 카드 UI를 분리해 모집 목록과 신청 목록에서 재사용하도록 정리했습니다.
- src/services/volunteerService.ts 에 봉사 신청 목록 조회와 신청 취소 API 호출 로직을 추가했습니다.
- src/types/volunteer.ts 에 신청 목록 응답과 volunteerApplicationId 타입을 반영했습니다.
- src/pages/esg/social/VolunteerCompletePage.tsx 에 신청 목록으로 이동하는 버튼을 추가했습니다.
- src/pages/esg/social/VolunteerDetailPage.tsx 와 src/pages/esg/social/VolunteerApplicationsPage.tsx 에서 뒤로가기 흐름을 보정해 목록 간 이동이 자연스럽게 이어지도록 수정했습니다.

## ✅ 테스트 결과
<!-- 테스트를 어떻게 했는지 (로컬 실행, API 테스트 등) -->
- [ ] 로컬에서 정상 동작 확인
- [ ] API 테스트 완료 (해당되면)
- [ ] 빌드 에러 없음

## 📸 스크린샷
<!-- UI 변경이 있으면 스크린샷 첨부 -->

## 💡 리뷰어에게
<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분 -->
