### PR TITLE
78 bug pdf qr 접속 버그

### DIFF
--- a/src/constants/routePaths.ts
+++ b/src/constants/routePaths.ts
@@ -46,6 +46,7 @@ export const ROUTE_PATHS = {
   myGrade: '/my/grade',
   myHistory: '/my/history',
   myFinance: '/my/finance',
+  myFinanceLoanManage: '/my/finance/loans',
   myFinanceSavingsHistory: '/my/finance/savings/:savingId',
   myFinanceLoanHistory: '/my/finance/loan',
   myPointManage: '/my/point-manage',

--- a/src/pages/finance/FinanceDonePage.tsx
+++ b/src/pages/finance/FinanceDonePage.tsx
@@ -63,7 +63,7 @@ export const FinanceDonePage = () => {
               fullWidth
               size="md"
               className="!h-[56px] !rounded-control"
-              onClick={() => navigate(ROUTE_PATHS.myFinance)}
+              onClick={() => navigate(doneState.primaryActionPath ?? ROUTE_PATHS.myFinance)}
             >
               {doneState.primaryActionLabel}
             </Button>

--- a/src/pages/finance/financeUi.ts
+++ b/src/pages/finance/financeUi.ts
@@ -6,6 +6,7 @@
   FinanceRateValue,
   FinanceUnavailableReason,
 } from '../../types/finance'
+import { ROUTE_PATHS } from '../../constants/routePaths'
 
 const numberFormatter = new Intl.NumberFormat('ko-KR')
 
@@ -123,6 +124,7 @@ export const buildSavingsDoneState = (product: FinanceListProduct): FinanceDoneS
     },
   ],
   primaryActionLabel: '\uB0B4 \uC801\uAE08 \uD655\uC778\uD558\uAE30',
+  primaryActionPath: ROUTE_PATHS.myFinance,
   secondaryActionLabel: '\uBA54\uC778\uC73C\uB85C \uAC00\uAE30',
 })
 
@@ -149,5 +151,6 @@ export const buildLoanDoneState = (
     { label: '\uB300\uCD9C \uAE30\uAC04', value: `${preview.durationMonths}\uAC1C\uC6D4` },
   ],
   primaryActionLabel: '\uB0B4 \uB300\uCD9C \uD604\uD669 \uBCF4\uAE30',
+  primaryActionPath: ROUTE_PATHS.myFinanceLoanManage,
   secondaryActionLabel: '\uBA54\uC778\uC73C\uB85C \uAC00\uAE30',
 })

--- a/src/pages/my/MyLoanHistoryPage.tsx
+++ b/src/pages/my/MyLoanHistoryPage.tsx
@@ -46,9 +46,17 @@ export const MyLoanHistoryPage = () => {
     }
   }
 
+  const handleBack = () => {
+    if (window.history.length > 1) {
+      navigate(-1)
+      return
+    }
+
+    navigate(ROUTE_PATHS.myFinanceLoanManage)
+  }
   return (
     <MainLayout
-      header={<ShopHeader title="내 대출 이력" onBack={() => navigate(ROUTE_PATHS.myFinance)} />}
+      header={<ShopHeader title="내 대출 이력" onBack={handleBack} />}
       nav={
         <BottomNavigation
           items={BOTTOM_NAVIGATION_ITEMS}
@@ -115,4 +123,3 @@ export const MyLoanHistoryPage = () => {
     </MainLayout>
   )
 }
-

--- a/src/pages/my/MyLoanManagePage.tsx
+++ b/src/pages/my/MyLoanManagePage.tsx
@@ -1,4 +1,4 @@
-﻿import { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Badge, Card, SectionHeader } from '../../components/common'
 import BottomNavigation from '../../components/layout/BottomNavigation'
@@ -7,19 +7,16 @@ import {
   BOTTOM_NAVIGATION_ITEMS,
   BOTTOM_NAVIGATION_ROUTE_BY_KEY,
 } from '../../constants/bottomNavigation'
-import {
-  ROUTE_PATHS,
-  getMyFinanceSavingsHistoryPath,
-} from '../../constants/routePaths'
+import { ROUTE_PATHS } from '../../constants/routePaths'
 import { getMyFinanceProducts } from '../../services/financeService'
-import type { FinanceApplicationStatus, FinanceMySaving } from '../../types/finance'
+import type { FinanceApplicationStatus, FinanceMyLoan } from '../../types/finance'
 import { ShopHeader } from '../shop/components/ShopHeader'
-import { formatCurrency, formatRate, formatRatePoint } from '../finance/financeUi'
+import { formatCurrency, formatDate, formatRate } from '../finance/financeUi'
 
 const isActiveFinanceStatus = (status: FinanceApplicationStatus) => status === 'ACTIVE'
 
 const getInactiveStatusLabel = (status: FinanceApplicationStatus) =>
-  status === 'COMPLETE' ? '완료됨' : '만료됨'
+  status === 'COMPLETE' ? '\uC644\uB8CC\uB428' : '\uB9CC\uB8CC\uB428'
 
 const sortByActiveStatus = <T extends { status: FinanceApplicationStatus }>(items: T[]) =>
   [...items].sort(
@@ -28,28 +25,28 @@ const sortByActiveStatus = <T extends { status: FinanceApplicationStatus }>(item
       Number(isActiveFinanceStatus(currentItem.status)),
   )
 
-export const MyFinancePage = () => {
+export const MyLoanManagePage = () => {
   const navigate = useNavigate()
-  const [savings, setSavings] = useState<FinanceMySaving[]>([])
+  const [loans, setLoans] = useState<FinanceMyLoan[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [errorMessage, setErrorMessage] = useState('')
 
   useEffect(() => {
-    const fetchMyFinanceProducts = async () => {
+    const fetchMyLoanProducts = async () => {
       try {
         setIsLoading(true)
         setErrorMessage('')
 
         const response = await getMyFinanceProducts()
-        setSavings(response.savings)
+        setLoans(response.loans)
       } catch {
-        setErrorMessage('적금 관리 정보를 불러오지 못했어요. 잠시 후 다시 시도해 주세요.')
+        setErrorMessage('\uB300\uCD9C \uAD00\uB9AC \uC815\uBCF4\uB97C \uBD88\uB7EC\uC624\uC9C0 \uBABB\uD588\uC5B4\uC694. \uC7A0\uC2DC \uD6C4 \uB2E4\uC2DC \uC2DC\uB3C4\uD574 \uC8FC\uC138\uC694.')
       } finally {
         setIsLoading(false)
       }
     }
 
-    void fetchMyFinanceProducts()
+    void fetchMyLoanProducts()
   }, [])
 
   const handleBottomNavigation = (key: string) => {
@@ -61,11 +58,11 @@ export const MyFinancePage = () => {
     }
   }
 
-  const sortedSavings = sortByActiveStatus(savings)
+  const sortedLoans = sortByActiveStatus(loans)
 
   return (
     <MainLayout
-      header={<ShopHeader title="적금 관리" onBack={() => navigate(ROUTE_PATHS.my)} />}
+      header={<ShopHeader title={'\uB300\uCD9C \uAD00\uB9AC'} onBack={() => navigate(ROUTE_PATHS.my)} />}
       nav={
         <BottomNavigation
           items={BOTTOM_NAVIGATION_ITEMS}
@@ -78,7 +75,7 @@ export const MyFinancePage = () => {
       <div className="mt-5 flex flex-col gap-5 pb-2">
         {isLoading ? (
           <Card className="!rounded-control !border-0 !px-5 !py-6 shadow-sm">
-            <p className="text-sm text-gray-500">적금 관리 정보를 불러오는 중입니다.</p>
+            <p className="text-sm text-gray-500">{'\uB300\uCD9C \uAD00\uB9AC \uC815\uBCF4\uB97C \uBD88\uB7EC\uC624\uB294 \uC911\uC785\uB2C8\uB2E4.'}</p>
           </Card>
         ) : null}
 
@@ -90,93 +87,79 @@ export const MyFinancePage = () => {
 
         <section className="flex flex-col gap-3">
           <SectionHeader
-            title={<span className="text-base font-semibold text-font-main">적금 관리</span>}
-            right={<span className="text-xs font-medium text-primary-400">{savings.length}건</span>}
+            title={<span className="text-base font-semibold text-font-main">{'\uB300\uCD9C \uAD00\uB9AC'}</span>}
+            right={<span className="text-xs font-medium text-primary-400">{`${loans.length}\uAC74`}</span>}
           />
 
-          {sortedSavings.length ? (
-            sortedSavings.map((saving) => {
-              const isMasterSaving = saving.productName === 'ESG 마스터 적금'
-              const isActiveSaving = isActiveFinanceStatus(saving.status)
+          {sortedLoans.length ? (
+            sortedLoans.map((loan) => {
+              const isActiveLoan = isActiveFinanceStatus(loan.status)
 
               return (
                 <Card
-                  key={saving.savingId}
-                  onClick={() => navigate(getMyFinanceSavingsHistoryPath(saving.savingId))}
+                  key={loan.loanId}
+                  onClick={() => navigate(ROUTE_PATHS.myFinanceLoanHistory)}
                   className="!gap-0 !rounded-control !border-0 !px-5 !py-4 shadow-sm"
                 >
                   <div className="flex items-start justify-between gap-3">
                     <div className="min-w-0">
                       <div className="flex flex-wrap items-center gap-2">
-                        <Badge tone="primary" variant="soft" className="!px-[8px] !py-[3px]">
-                          SAVINGS
+                        <Badge tone="neutral" variant="soft" className="!px-[8px] !py-[3px]">
+                          LOAN
                         </Badge>
-                        {!isActiveSaving ? (
+                        {!isActiveLoan ? (
                           <Badge tone="neutral" variant="soft" className="!px-[8px] !py-[3px]">
-                            {getInactiveStatusLabel(saving.status)}
+                            {getInactiveStatusLabel(loan.status)}
                           </Badge>
                         ) : null}
                       </div>
                       <p className="mt-3 text-[16px] font-semibold leading-[1.2] text-font-main">
-                        {saving.productName}
+                        {loan.productName}
                       </p>
                     </div>
                     <div className="text-right">
-                      <p className="text-[10px] font-medium text-gray-400">적용 금리</p>
-                      <p className="mt-1 text-[18px] font-bold leading-none text-primary-500">
-                        {formatRate(saving.appliedRate).replace('연 ', '')}
+                      <p className="text-[10px] font-medium text-gray-400">{'\uAE08\uB9AC'}</p>
+                      <p className="mt-1 text-[25px] font-bold leading-none text-primary-500">
+                        {formatRate(loan.currentRate).replace('\uC5F0 ', '')}
                       </p>
                     </div>
                   </div>
 
                   <div className="mt-6 grid grid-cols-2 gap-5">
                     <div className="flex flex-col gap-1">
-                      <span className="text-[11px] text-gray-400">누적 납입액</span>
+                      <span className="text-[11px] text-gray-400">{'\uB204\uC801 \uC0C1\uD658\uC561'}</span>
                       <span className="text-[16px] font-semibold text-gray-700">
-                        {formatCurrency(saving.paidAmount).replace('원', ' 원')}
+                        {formatCurrency(loan.paidAmount).replace('\uC6D0', ' \uC6D0')}
                       </span>
                     </div>
                     <div className="flex flex-col items-end gap-1 text-right">
-                      <span className="text-[11px] text-gray-400">우대 금리</span>
+                      <span className="text-[11px] text-gray-400">{'\uC794\uC5EC \uAE08\uC561'}</span>
                       <span className="text-[16px] font-semibold text-primary-500">
-                        {formatRatePoint(saving.addedRate)}
+                        {formatCurrency(loan.remainingAmount).replace('\uC6D0', ' \uC6D0')}
                       </span>
                     </div>
                   </div>
 
                   <div className="mt-5 flex items-center justify-between border-t border-gray-100 pt-4">
                     <div>
-                      <p className="text-[11px] text-gray-400">납입 회차</p>
+                      <p className="text-[11px] text-gray-400">{'\uC0C1\uD658 \uD68C\uCC28'}</p>
                       <p className="mt-1 text-[12px] font-medium text-gray-600">
-                        {saving.paymentCount}회차
+                        {`${loan.repaymentCount}\uD68C\uCC28`}
                       </p>
                     </div>
                     <div className="text-right">
-                      <p className="text-[11px] text-gray-400">월 납입액</p>
+                      <p className="text-[11px] text-gray-400">{'\uB2E4\uC74C \uC0C1\uD658\uC77C'}</p>
                       <p className="mt-1 text-[12px] font-medium text-gray-600">
-                        {formatCurrency(saving.monthlyAmount).replace('원', ' 원')}
+                        {formatDate(loan.nextRepaymentDate)}
                       </p>
                     </div>
                   </div>
-
-                  {isMasterSaving ? (
-                    <div className="mt-4 flex items-center justify-between rounded-[8px] bg-gray-50 px-3 py-3">
-                      <span className="text-[11px] font-medium text-gray-500">마스터 우대</span>
-                      <span
-                        className={`text-[12px] font-semibold ${
-                          saving.masterBonusEligible ? 'text-primary-500' : 'text-gray-500'
-                        }`}
-                      >
-                        {saving.masterBonusEligible ? '자격 유지' : '자격 소멸'}
-                      </span>
-                    </div>
-                  ) : null}
                 </Card>
               )
             })
           ) : !isLoading ? (
             <Card className="!rounded-control !border-0 !px-5 !py-6 shadow-sm">
-              <p className="text-sm text-gray-500">현재 가입 중인 적금 상품이 없습니다.</p>
+              <p className="text-sm text-gray-500">{'\uD604\uC7AC \uC774\uC6A9 \uC911\uC778 \uB300\uCD9C \uC0C1\uD488\uC774 \uC5C6\uC2B5\uB2C8\uB2E4.'}</p>
             </Card>
           ) : null}
         </section>
@@ -184,4 +167,3 @@ export const MyFinancePage = () => {
     </MainLayout>
   )
 }
-

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -1,6 +1,6 @@
 ﻿import { Coins, FileChartColumn, Landmark, ShieldCheck, UserRound } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
-import { Card, Icons, SectionHeader } from '../../components/common'
+import { Card, Icons } from '../../components/common'
 import BottomNavigation from '../../components/layout/BottomNavigation'
 import MainLayout from '../../components/layout/MainLayout'
 import {
@@ -79,27 +79,49 @@ export const MyPage = () => {
     navigate(ROUTE_PATHS.login)
   }
 
-  const renderMenuCard = (items: typeof menuItems) => (
-    <Card className="!gap-0 !p-0">
-      {items.map((item, index) => (
-        <button
-          key={item.key}
-          type="button"
-          onClick={() => navigate(item.path)}
-          className={`flex w-full items-center justify-between px-5 py-5 text-left ${
-            index < items.length - 1 ? 'border-b border-gray-100' : ''
-          }`}
-        >
-          <div className="flex items-center gap-3">
-            <div className="flex h-9 w-9 items-center justify-center rounded-full border border-gray-100 bg-gray-50 text-gray-500">
-              {item.icon}
-            </div>
-            <span className="text-[15px] font-medium text-font-main">{item.label}</span>
-          </div>
+  const renderMenuItems = (items: typeof menuItems, showBottomBorder = false) => (
+    <>
+      {items.map((item, index) => {
+        const hasDivider = index < items.length - 1 || showBottomBorder
 
-          <Icons.ArrowRight className="text-gray-300" size={20} />
-        </button>
-      ))}
+        return (
+          <button
+            key={item.key}
+            type="button"
+            onClick={() => navigate(item.path)}
+            className={`flex w-full items-center justify-between px-5 py-5 text-left ${
+              hasDivider ? 'border-b border-gray-100' : ''
+            }`}
+          >
+            <div className="flex items-center gap-3">
+              <div className="flex h-9 w-9 items-center justify-center rounded-full border border-gray-100 bg-gray-50 text-gray-500">
+                {item.icon}
+              </div>
+              <span className="text-[15px] font-medium text-font-main">{item.label}</span>
+            </div>
+
+            <Icons.ArrowRight className="text-gray-300" size={20} />
+          </button>
+        )
+      })}
+    </>
+  )
+
+  const renderActivityFinanceMenuCard = () => (
+    <Card className="!gap-0 !p-0 mt-3">
+      <div className="px-5 pb-2 pt-5">
+        <p className="text-xs font-semibold tracking-[0.18em] text-gray-400">활동</p>
+      </div>
+      {renderMenuItems(activityMenuItems, financeMenuItems.length > 0)}
+
+      {financeMenuItems.length > 0 ? (
+        <>
+          <div className="px-5 pb-2 pt-5">
+            <p className="text-xs font-semibold tracking-[0.18em] text-gray-400">금융</p>
+          </div>
+          {renderMenuItems(financeMenuItems)}
+        </>
+      ) : null}
     </Card>
   )
 
@@ -117,9 +139,15 @@ export const MyPage = () => {
     >
       <section className="mt-2 flex flex-col gap-5">
         <section className="flex flex-col gap-3">
-          <SectionHeader title="계정" className="px-1" />
+          {renderActivityFinanceMenuCard()}
+        </section>
 
+
+        <section className="flex flex-col gap-3">
           <Card className="!gap-0 !p-0">
+            <div className="px-5 pb-2 pt-5">
+              <p className="text-xs font-semibold tracking-[0.18em] text-gray-400">계정</p>
+            </div>
             {accountMenuItems.map((item) => (
               <button
                 key={item.key}
@@ -151,15 +179,6 @@ export const MyPage = () => {
           </Card>
         </section>
 
-        <section className="flex flex-col gap-3">
-          <SectionHeader title="활동" className="px-1" />
-          {renderMenuCard(activityMenuItems)}
-        </section>
-
-        <section className="flex flex-col gap-3">
-          <SectionHeader title="금융" className="px-1" />
-          {renderMenuCard(financeMenuItems)}
-        </section>
       </section>
     </MainLayout>
   )

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -38,10 +38,16 @@ const menuItems = [
     path: ROUTE_PATHS.activitySocialStore,
   },
   {
-    key: 'finance',
-    label: '금융 상품 관리',
+    key: 'financeSavings',
+    label: '적금 관리',
     icon: <Landmark size={18} />,
     path: ROUTE_PATHS.myFinance,
+  },
+  {
+    key: 'financeLoan',
+    label: '대출 관리',
+    icon: <Landmark size={18} />,
+    path: ROUTE_PATHS.myFinanceLoanManage,
   },
   {
     key: 'point',
@@ -55,7 +61,9 @@ const accountMenuItems = menuItems.filter((item) => item.key === 'profile')
 const activityMenuItems = menuItems.filter((item) =>
   ['grade', 'storePurchase', 'report', 'point'].includes(item.key),
 )
-const financeMenuItems = menuItems.filter((item) => item.key === 'finance')
+const financeMenuItems = menuItems.filter((item) =>
+  ['financeSavings', 'financeLoan'].includes(item.key),
+)
 
 export const MyPage = () => {
   const navigate = useNavigate()

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -41,6 +41,7 @@ import { MyFinancePage } from '../pages/my/MyFinancePage'
 import { MyGradePage } from '../pages/my/MyGradePage'
 import { MyHistoryPage } from '../pages/my/MyHistoryPage'
 import { MyLoanHistoryPage } from '../pages/my/MyLoanHistoryPage'
+import { MyLoanManagePage } from '../pages/my/MyLoanManagePage'
 import { MyPointManagePage } from '../pages/my/MyPointManagePage'
 import { MyProfilePage } from '../pages/my/MyProfilePage'
 import { MyReportPage } from '../pages/my/MyReportPage'
@@ -48,6 +49,7 @@ import { MySavingsHistoryPage } from '../pages/my/MySavingsHistoryPage'
 import { MyPage } from '../pages/my/MyPage'
 import { NotFoundPage } from '../pages/NotFoundPage'
 import { RecommendPage } from '../pages/recommend/RecommendPage'
+import { ReportVerificationPage } from '../pages/report/ReportVerificationPage'
 import { EnvironmentEntryModalRoute } from '../pages/esg/env/EnvironmentEntryModalRoute'
 import { EnvironmentEntryPage } from '../pages/esg/env/EnvironmentEntryPage'
 import { EnvironmentVerifyPage } from '../pages/esg/env/EnvironmentVerifyPage'
@@ -73,6 +75,8 @@ function AppRoutes() {
           path={ROUTE_PATHS.root}
           element={<Navigate replace to={ROUTE_PATHS.home} />}
         />
+
+        <Route path={ROUTE_PATHS.reportVerify} element={<ReportVerificationPage />} />
 
         <Route element={<PublicOnlyRoute />}>
           <Route path={ROUTE_PATHS.login} element={<LoginPage />} />
@@ -174,6 +178,7 @@ function AppRoutes() {
             <Route path={ROUTE_PATHS.myGrade} element={<MyGradePage />} />
             <Route path={ROUTE_PATHS.myHistory} element={<MyHistoryPage />} />
             <Route path={ROUTE_PATHS.myFinance} element={<MyFinancePage />} />
+            <Route path={ROUTE_PATHS.myFinanceLoanManage} element={<MyLoanManagePage />} />
             <Route path={ROUTE_PATHS.myFinanceSavingsHistory} element={<MySavingsHistoryPage />} />
             <Route path={ROUTE_PATHS.myFinanceLoanHistory} element={<MyLoanHistoryPage />} />
             <Route path={ROUTE_PATHS.myPointManage} element={<MyPointManagePage />} />

--- a/src/types/finance.ts
+++ b/src/types/finance.ts
@@ -33,6 +33,7 @@ export interface FinanceProductCompletion {
   description: string
   fields: FinanceInfoField[]
   primaryActionLabel: string
+  primaryActionPath?: string
   secondaryActionLabel: string
 }
 
@@ -191,5 +192,6 @@ export interface FinanceDoneState {
   description: string
   fields: FinanceInfoField[]
   primaryActionLabel: string
+  primaryActionPath?: string
   secondaryActionLabel: string
 }


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이슈 번호를 적어주세요. 머지 시 자동으로 이슈가 닫힙니다. -->
Closes #

## 📌 작업 내용
<!-- 어떤 작업을 했는지 간단히 설명 -->
- 금융 관리 화면을 적금 관리와 대출 관리로 프론트에서 분리
- PDF QR이 여는 /report/verify/:token 경로가 기존 인증서 확인 페이지로 연결되도록 라우터 추가

## 🛠 변경 사항
<!-- 주요 변경 파일이나 로직을 설명 -->
- src/pages/my/MyPage.tsx 마이페이지 금융 메뉴를 적금 관리, 대출 관리로 분리
- src/pages/my/MyFinancePage.tsx 기존 금융 통합 화면에서 적금 관리만 보이도록 정리
- src/pages/my/MyLoanManagePage.tsx 대출 관리 전용 페이지를 새로 추가
- src/pages/my/MyLoanHistoryPage.tsx 대출 이력 페이지 뒤로가기 동선을 대출 관리 화면 기준으로 보완
- src/constants/routePaths.ts, src/routes/Router.tsx 대출 관리 라우트와 인증서 확인 라우트 등록
- src/pages/finance/financeUi.ts, src/pages/finance/FinanceDonePage.tsx, src/types/finance.ts 적금/대출 신청 완료 후 각 관리 화면으로 자연스럽게 이동하도록 상태값 확장

## ✅ 테스트 결과
<!-- 테스트를 어떻게 했는지 (로컬 실행, API 테스트 등) -->
- [x] 로컬에서 정상 동작 확인
- [x] API 테스트 완료 (해당되면)
- [x] 빌드 에러 없음

## 📸 스크린샷
<!-- UI 변경이 있으면 스크린샷 첨부 -->

## 💡 리뷰어에게
<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분 -->
