### PR TITLE
feat: 금융 상품 가입 불가 사유 표시

### DIFF
--- a/src/pages/finance/FinanceDetailPage.tsx
+++ b/src/pages/finance/FinanceDetailPage.tsx
@@ -25,6 +25,7 @@ import {
   buildSavingsDoneState,
   buildSavingsRateSummary,
   formatRate,
+  getFinanceUnavailableReasonLabel,
 } from './financeUi'
 
 interface FinanceDetailLocationState {
@@ -157,6 +158,11 @@ export const FinanceDetailPage = () => {
       return
     }
 
+    if (!savingsProduct.available) {
+      setErrorMessage(getFinanceUnavailableReasonLabel(savingsProduct.unavailableReason))
+      return
+    }
+
     try {
       setIsSubmitting(true)
       await applyFinanceSavings({ productId: savingsProduct.id })
@@ -269,6 +275,10 @@ export const FinanceDetailPage = () => {
   if (productType === 'SAVINGS' && savingsProduct) {
     const detailFields = buildSavingsDetailFields(savingsProduct)
     const rateHighlightLabel = formatRate(savingsProduct.maxRate)
+    const isSavingsAvailable = savingsProduct.available
+    const savingsUnavailableLabel = getFinanceUnavailableReasonLabel(
+      savingsProduct.unavailableReason,
+    )
 
     return (
       <div className="relative min-h-screen bg-bg-light font-pretendard">
@@ -326,6 +336,11 @@ export const FinanceDetailPage = () => {
                 <p className="mt-[6px] text-[12px] leading-[22.75px] text-gray-600">
                   {savingsProduct.description ?? ''}
                 </p>
+                {!isSavingsAvailable ? (
+                  <p className="mt-2 text-[12px] leading-[22.75px] text-primary-500">
+                    {savingsUnavailableLabel}
+                  </p>
+                ) : null}
               </Card>
 
               {renderNoticeBlock(FINANCE_NOTICE_LINES)}
@@ -347,9 +362,9 @@ export const FinanceDetailPage = () => {
               size="md"
               onClick={handleSavingsApply}
               className="!h-[56px]"
-              disabled={isSubmitting}
+              disabled={isSubmitting || !isSavingsAvailable}
             >
-              {isSubmitting ? '가입 처리 중...' : '가입하기'}
+              {isSubmitting ? '가입 처리 중...' : isSavingsAvailable ? '가입하기' : savingsUnavailableLabel}
             </Button>
           </div>
         </div>

--- a/src/pages/finance/FinancePage.tsx
+++ b/src/pages/finance/FinancePage.tsx
@@ -13,7 +13,20 @@ import type { FinanceListProduct, SavingsRecommendResponse } from '../../types/f
 import { ShopHeader } from '../shop/components/ShopHeader'
 import { FinanceTabs, type FinanceTabValue } from './components/FinanceTabs'
 import { SavingsRecommendCard } from './components/SavingsRecommendCard'
-import { FINANCE_SECTION_LABELS, buildLoanLimitRateLabel, formatRate } from './financeUi'
+import {
+  FINANCE_SECTION_LABELS,
+  formatCurrency,
+  formatRate,
+  getFinanceUnavailableReasonLabel,
+} from './financeUi'
+
+const getProductCardClassName = (product: FinanceListProduct, baseClassName: string) =>
+  [
+    baseClassName,
+    product.available ? '' : '!bg-gray-50 opacity-80',
+  ]
+    .filter(Boolean)
+    .join(' ')
 
 export const FinancePage = () => {
   const navigate = useNavigate()
@@ -149,20 +162,37 @@ export const FinancePage = () => {
                       state: { productType: product.type },
                     })
                   }
-                  className="!gap-0 !rounded-control !border-0 !px-[26px] !py-4 shadow-sm"
+                  className={getProductCardClassName(
+                    product,
+                    '!gap-0 !rounded-control !border-0 !px-[26px] !py-4 shadow-sm',
+                  )}
                 >
                   <div className="flex min-h-[58px] items-center justify-between gap-5">
-                    <div className="min-w-0 max-w-[160px]">
-                      <p className="truncate text-base font-semibold leading-[1.2] text-font-main">
-                        {product.name}
-                      </p>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <p className="break-keep text-base font-semibold leading-[1.2] text-font-main">
+                          {product.name}
+                        </p>
+                        {!product.available ? (
+                          <Badge tone="neutral" variant="soft" className="shrink-0 text-[11px]">
+                            가입 불가
+                          </Badge>
+                        ) : null}
+                      </div>
                       <p className="mt-2 whitespace-pre-line text-xs leading-[1.2] text-gray-600">
-                        {product.subtitle ?? ''}
+                        {product.available
+                          ? product.subtitle ?? ''
+                          : getFinanceUnavailableReasonLabel(product.unavailableReason)}
                       </p>
                     </div>
 
                     <div className="flex shrink-0 items-center">
-                      <span className="text-base font-bold leading-none text-primary-500">
+                      <span
+                        className={[
+                          'text-base font-bold leading-none',
+                          product.available ? 'text-primary-500' : 'text-gray-400',
+                        ].join(' ')}
+                      >
                         {formatRate(product.maxRate)}
                       </span>
                       <Icons.ArrowRight className="text-gray-500" size={24} />
@@ -204,19 +234,20 @@ export const FinancePage = () => {
                     state: { productType: loanProduct.type },
                   })
                 }
-                className="!gap-0 !rounded-control !border-0 !px-5 !py-[26px] shadow-sm"
+                className={getProductCardClassName(
+                  loanProduct,
+                  '!gap-0 !rounded-control !border-0 !px-5 !py-[26px] shadow-sm',
+                )}
               >
                 <div className="flex items-start justify-between gap-4">
                   <div className="min-w-0 max-w-[235px]">
-                    {loanProduct.available ? (
-                      <Badge
-                        tone="primary"
-                        variant="soft"
-                        className="mb-3 !rounded-[4px] !px-[6px] !py-[2px] text-xs font-medium text-primary-400"
-                      >
-                        신청 가능
-                      </Badge>
-                    ) : null}
+                    <Badge
+                      tone={loanProduct.available ? 'primary' : 'neutral'}
+                      variant="soft"
+                      className="mb-3 !rounded-[4px] !px-[6px] !py-[2px] text-xs font-medium"
+                    >
+                      {loanProduct.available ? '신청 가능' : '신청 불가'}
+                    </Badge>
                     <p className="text-[20px] font-bold leading-[1.2] text-font-main">
                       {loanProduct.name}
                     </p>
@@ -228,11 +259,30 @@ export const FinancePage = () => {
                   <Icons.ArrowRight className="mt-5 shrink-0 text-gray-500" size={24} />
                 </div>
 
-                <div className="mt-8 rounded-control bg-gray-50 px-9 py-6 shadow-sm">
-                  <p className="text-xs leading-[1.625] text-gray-600">현재 적용 조건</p>
-                  <p className="mt-1 text-base font-bold leading-7 text-font-main">
-                    {buildLoanLimitRateLabel(loanProduct.loanLimit, loanProduct.appliedRate)}
+                <div className="mt-7 border-t border-gray-100 pt-5">
+                  <p className="text-xs font-medium leading-[1.625] text-gray-500">
+                    현재 적용 조건
                   </p>
+                  {loanProduct.available ? (
+                    <div className="mt-3 grid grid-cols-2 gap-3">
+                      <div className="rounded-[14px] bg-primary-50/70 px-4 py-3">
+                        <p className="text-[11px] font-medium text-primary-400">대출 한도</p>
+                        <p className="mt-1 text-base font-bold leading-6 text-font-main">
+                          {formatCurrency(loanProduct.loanLimit)}
+                        </p>
+                      </div>
+                      <div className="rounded-[14px] bg-gray-50 px-4 py-3">
+                        <p className="text-[11px] font-medium text-gray-500">적용 금리</p>
+                        <p className="mt-1 text-base font-bold leading-6 text-primary-500">
+                          {formatRate(loanProduct.appliedRate)}
+                        </p>
+                      </div>
+                    </div>
+                  ) : (
+                    <p className="mt-2 break-keep text-base font-semibold leading-6 text-font-main">
+                      {getFinanceUnavailableReasonLabel(loanProduct.unavailableReason)}
+                    </p>
+                  )}
                 </div>
               </Card>
             ) : !isLoading && !errorMessage ? (

--- a/src/pages/finance/financeUi.ts
+++ b/src/pages/finance/financeUi.ts
@@ -23,9 +23,21 @@ export const FINANCE_NOTICE_LINES = [
 
 export const LOAN_PREVIEW_REASON_LABEL: Record<FinanceUnavailableReason, string> = {
   AVAILABLE: '\uC2E0\uCCAD \uAC00\uB2A5\uD55C \uC0C1\uD488\uC785\uB2C8\uB2E4.',
+  ALREADY_JOINED: '이미 가입한 상품입니다.',
+  LOW_SCORE_FOR_ESG_MASTER: 'ESG 마스터 적금은 900점 이상부터 가입할 수 있어요.',
   LOW_SCORE: '\uD604\uC7AC ESG \uC810\uC218\uB85C\uB294 \uB300\uCD9C \uC2E0\uCCAD\uC774 \uC5B4\uB824\uC6CC\uC694.',
   HAS_ACTIVE_LOAN: '\uAE30\uC874 \uB300\uCD9C\uC744 \uBCF4\uC720 \uC911\uC774\uB77C \uCD94\uAC00 \uB300\uCD9C\uC774 \uBD88\uAC00\uD569\uB2C8\uB2E4.',
   LOAN_BLOCKED: '\uD328\uB110\uD2F0 \uC0C1\uD0DC\uB85C \uB300\uCD9C \uC2E0\uCCAD\uC774 \uC81C\uD55C\uB418\uC5B4 \uC788\uC5B4\uC694.',
+}
+
+export const getFinanceUnavailableReasonLabel = (
+  reason: FinanceUnavailableReason | null | undefined,
+) => {
+  if (!reason || reason === 'AVAILABLE') {
+    return '가입 가능한 상품입니다.'
+  }
+
+  return LOAN_PREVIEW_REASON_LABEL[reason] ?? '현재 가입이 어려운 상품입니다.'
 }
 
 export const formatCurrency = (value: number | null | undefined) => {

--- a/src/types/finance.ts
+++ b/src/types/finance.ts
@@ -3,6 +3,8 @@ export type FinancialProductType = FinanceProductType
 export type FinanceProductListQueryType = 'loan' | 'savings'
 export type FinanceUnavailableReason =
   | 'AVAILABLE'
+  | 'ALREADY_JOINED'
+  | 'LOW_SCORE_FOR_ESG_MASTER'
   | 'LOW_SCORE'
   | 'HAS_ACTIVE_LOAN'
   | 'LOAN_BLOCKED'
@@ -87,6 +89,7 @@ export interface FinanceListProduct {
   appliedRate: FinanceRateValue | null
   loanLimit: number | null
   available: boolean
+  unavailableReason: FinanceUnavailableReason | null
   durationMonths: number
   monthlyPaymentAmount: number | null
   description: string | null


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이슈 번호를 적어주세요. 머지 시 자동으로 이슈가 닫힙니다. -->
Closes #92

## 📌 작업 내용
- 금융 상품 목록 API에 추가된 `unavailableReason` 반영
- 가입/신청 불가 상품을 비활성 상태로 표시
- 적금 상세 화면에서 가입 불가 시 버튼 비활성화 및 안내 문구 표시

## 🛠 변경 사항
- 금융 상품 응답 타입에 `unavailableReason` 추가
- `ALREADY_JOINED`, `LOW_SCORE_FOR_ESG_MASTER` 등 사유별 문구 처리
- 이미 가입한 적금도 목록에 노출하되 가입 불가 상태로 표시
- 상품명이 말줄임 처리되지 않고 전체 표시되도록 수정

## ✅ 테스트 결과
- [x] 빌드 에러 없음